### PR TITLE
fix(sbf): replace the 64K instruction cap with the on-chain account bound

### DIFF
--- a/include/neverd/sbf/SBFConstants.h
+++ b/include/neverd/sbf/SBFConstants.h
@@ -22,7 +22,13 @@ inline constexpr size_t kOpcodeOffset = 0;
 inline constexpr size_t kRegisterByteOffset = 1;
 inline constexpr size_t kBranchOffsetOffset = 2;
 inline constexpr size_t kImmediateOffset = 4;
-inline constexpr size_t kMaxInstructions = 65'536;
+
+// The Anza sbpf loader/verifier imposes no instruction-count cap; the only
+// on-chain bound is the maximum program account data length (10 MiB).
+// Anything larger cannot be deployed, so treat it as malformed input.
+inline constexpr size_t kMaxProgramAccountSize = 10 * 1024 * 1024;
+inline constexpr size_t kMaxInstructions =
+    kMaxProgramAccountSize / kInstructionSize;
 
 inline constexpr unsigned kRegisterEncodingBits = 4;
 inline constexpr uint8_t kRegisterEncodingMask =


### PR DESCRIPTION
## Problem

`neverd lift` rejects large real-world Solana programs:

```
error: program exceeds the SBF instruction limit
```

`include/neverd/sbf/SBFConstants.h` caps programs at 65,536 instructions (`kMaxInstructions`). However, the Anza SBPF loader/verifier imposes **no instruction-count limit** — the only on-chain bound is the 10 MiB maximum program account data length.

Real production programs exceed the 64K cap by a wide margin. For example, Jupiter Aggregator v6 (`JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4`) — a program actively running on mainnet — contains **222,183 instructions** (1,777,464 bytes of `.text`), and NeverD refuses to lift it.

## Fix

Replace the hard-coded 64K cap with the actual on-chain bound:

```cpp
inline constexpr size_t kMaxProgramAccountSize = 10 * 1024 * 1024;
inline constexpr size_t kMaxInstructions = kMaxProgramAccountSize / kInstructionSize;
```

This yields a limit of 1,310,720 instructions — the maximum number of 8-byte instructions that can physically fit in a program account.

## Verification

- `ctest -L NeverDSBF`: 36/36 pass
- Successfully lifted Jupiter Aggregator v6 (222,183 instructions), which was previously rejected

## References

- [anza-xyz/sbpf](https://github.com/anza-xyz/sbpf) — the verifier checks program length against the account data size, never against an instruction count
- Solana `MAX_ACCOUNT_DATA_LEN` = 10 MiB

🤖 Generated with [Claude Code](https://claude.com/claude-code)
