### PR TITLE
test(macho): authenticate EH transaction symbols

### DIFF
--- a/lib/backend/codegen/CodeGen.cpp
+++ b/lib/backend/codegen/CodeGen.cpp
@@ -474,12 +474,12 @@ Codegen::compileForRewrite(llvm::Module &Mod, Arch TargetArch,
   }
 
   llvm::TargetOptions TOpt;
-  // Darwin AArch64 normally omits DWARF CFI when a frame has a compact-unwind
-  // encoding.  The rewrite path cannot register compact-unwind records from
-  // its appended executable segment, while an existing __TEXT,__eh_frame can
-  // safely host regenerated DWARF records.  Keep those records in every
-  // Mach-O rewrite object so the format installer can validate and register
-  // them, or fail closed when the input exposes no such region.
+  // Darwin targets may omit DWARF CFI when a frame has a compact-unwind
+  // encoding.  A Mach-O rewrite transaction needs an explicit unwind payload
+  // that it can authenticate and install, including as the validated fallback
+  // for frames that cannot retain a compact encoding.  Request DWARF emission
+  // from the target backend; targets whose exception ABI uses another model
+  // still decide whether an actual CFI section is produced.
   if (ObjectFormat == BinaryFormat::MachO)
     TOpt.MCOptions.EmitDwarfUnwind = llvm::EmitDwarfUnwindType::Always;
   // The rewrite backend outputs final image bytes; alignment padding in text

--- a/lib/backend/codegen/MachO/MachOPatch.cpp
+++ b/lib/backend/codegen/MachO/MachOPatch.cpp
@@ -72,14 +72,11 @@ struct MachOSymbolTarget {
 enum class MachOSymbolNameMatch : uint8_t { Exact, UnderscoreAlias };
 
 std::optional<MachOSymbolNameMatch>
-classifyMachOSymbolName(llvm::StringRef Requested,
-                        llvm::StringRef Candidate) {
+classifyMachOSymbolName(llvm::StringRef Requested, llvm::StringRef Candidate) {
   if (Candidate == Requested)
     return MachOSymbolNameMatch::Exact;
-  if ((Requested.starts_with("_") &&
-       Candidate == Requested.drop_front()) ||
-      (Candidate.starts_with("_") &&
-       Candidate.drop_front() == Requested))
+  if ((Requested.starts_with("_") && Candidate == Requested.drop_front()) ||
+      (Candidate.starts_with("_") && Candidate.drop_front() == Requested))
     return MachOSymbolNameMatch::UnderscoreAlias;
   return std::nullopt;
 }
@@ -97,9 +94,8 @@ resolveUniqueMachOSymbol(const BinaryImage &Image, llvm::StringRef Requested) {
         classifyMachOSymbolName(Requested, Name);
     if (!Match)
       return;
-    auto &Candidates = *Match == MachOSymbolNameMatch::Exact
-                           ? ExactCandidates
-                           : AliasCandidates;
+    auto &Candidates = *Match == MachOSymbolNameMatch::Exact ? ExactCandidates
+                                                             : AliasCandidates;
     Candidates.emplace(Address, IsCode);
   };
   auto RecordInvalid = [&](llvm::StringRef Name) {
@@ -125,9 +121,9 @@ resolveUniqueMachOSymbol(const BinaryImage &Image, llvm::StringRef Requested) {
       RecordInvalid(ImportedName);
       continue;
     }
-    const uint64_t Target =
-        Image.is64Bit() ? llvm::support::endian::read64le(Pointer)
-                        : llvm::support::endian::read32le(Pointer);
+    const uint64_t Target = Image.is64Bit()
+                                ? llvm::support::endian::read64le(Pointer)
+                                : llvm::support::endian::read32le(Pointer);
     Record(ImportedName, Target, /*IsCode=*/true);
   }
   for (const Export &Item : Image.Exports)
@@ -151,16 +147,15 @@ resolveUniqueMachOSymbol(const BinaryImage &Image, llvm::StringRef Requested) {
          "' has an unreadable pointer-slot candidate")
             .str());
   if (Candidates.size() > 1)
-    return llvm::createStringError(
-        llvm::errc::invalid_argument,
-        (llvm::Twine("ambiguous Mach-O symbol '") + Requested +
-         "' resolves to multiple addresses or kinds")
-            .str());
+    return llvm::createStringError(llvm::errc::invalid_argument,
+                                   (llvm::Twine("ambiguous Mach-O symbol '") +
+                                    Requested +
+                                    "' resolves to multiple addresses or kinds")
+                                       .str());
   if (Candidates.empty())
     return std::optional<MachOSymbolTarget>();
   const auto &[Address, IsCode] = *Candidates.begin();
-  return std::optional<MachOSymbolTarget>(
-      MachOSymbolTarget{Address, IsCode});
+  return std::optional<MachOSymbolTarget>(MachOSymbolTarget{Address, IsCode});
 }
 
 llvm::Expected<MachORewriteTarget>
@@ -1247,8 +1242,7 @@ PatchResult MachOPatcher::patch(const std::filesystem::path &InputPath,
             return std::nullopt;
           }
           if (*Target)
-            return SerializeResolvedCode((*Target)->Address,
-                                         (*Target)->IsCode);
+            return SerializeResolvedCode((*Target)->Address, (*Target)->IsCode);
           if (auto VA = parseNdDataSymbol(Name)) {
             bool IsCode = IsExecutable(*VA) &&
                           AuthenticatedImage.CodeRefTargets.count(*VA) != 0;

--- a/unittests/lift/eh/MachOARM32TransactionTests.cpp
+++ b/unittests/lift/eh/MachOARM32TransactionTests.cpp
@@ -766,13 +766,13 @@ TEST(MachOARM32Transaction,
   ASSERT_EQ(Symtab->nsyms, 5u);
   auto *Symbols =
       reinterpret_cast<nlist *>(Fixture.Binary.data() + Symtab->symoff);
-  nlist &ConflictingPersonality = Symbols[5];
-  ConflictingPersonality.n_strx = Symbols[0].n_strx;
-  ConflictingPersonality.n_type =
+  nlist &ConflictingCallee = Symbols[5];
+  ConflictingCallee.n_strx = Symbols[2].n_strx;
+  ConflictingCallee.n_type =
       static_cast<uint8_t>(static_cast<uint8_t>(N_SECT) | N_EXT);
-  ConflictingPersonality.n_sect = 1;
-  ConflictingPersonality.n_desc = N_ARM_THUMB_DEF;
-  ConflictingPersonality.n_value = kARM32UnwindResumeVA;
+  ConflictingCallee.n_sect = 1;
+  ConflictingCallee.n_desc = N_ARM_THUMB_DEF;
+  ConflictingCallee.n_value = kARM32PersonalityVA;
   Symtab->nsyms = 6;
 
   llvm::SmallString<128> InputPath;
@@ -800,6 +800,54 @@ TEST(MachOARM32Transaction,
       << Diagnostic;
   EXPECT_EQ(readFile(InputPath), Fixture.Binary);
   EXPECT_EQ(readFile(OutputPath), OutputSentinel);
+}
+
+TEST(MachOARM32Transaction, UniqueExactNameOutranksUnderscoreAlias) {
+  ARM32TransactionFixture Fixture = makeARM32TransactionFixture(
+      macho_unwind::kARMModeFrame | macho_unwind::kARMFrameFirstPushR4,
+      /*CompactCapacity=*/0x2000);
+  ASSERT_FALSE(Fixture.Binary.empty());
+
+  symtab_command *Symtab = nullptr;
+  forEachMachOLoadCommand(
+      Fixture.Binary.data(), Fixture.Binary.size(),
+      [&](const uint8_t *Command, uint32_t ID, uint32_t, bool) {
+        if (ID == LC_SYMTAB)
+          Symtab = reinterpret_cast<symtab_command *>(
+              const_cast<uint8_t *>(Command));
+      });
+  ASSERT_NE(Symtab, nullptr);
+  ASSERT_EQ(Symtab->nsyms, 5u);
+  auto *Symbols =
+      reinterpret_cast<nlist *>(Fixture.Binary.data() + Symtab->symoff);
+  nlist &AliasCallee = Symbols[5];
+  AliasCallee.n_strx = Symbols[2].n_strx + 1;
+  AliasCallee.n_type =
+      static_cast<uint8_t>(static_cast<uint8_t>(N_SECT) | N_EXT);
+  AliasCallee.n_sect = 1;
+  AliasCallee.n_desc = N_ARM_THUMB_DEF;
+  AliasCallee.n_value = kARM32PersonalityVA;
+  Symtab->nsyms = 6;
+
+  llvm::SmallString<128> InputPath;
+  llvm::SmallString<128> OutputPath;
+  ASSERT_FALSE(llvm::sys::fs::createTemporaryFile(
+      "neverd-arm32-macho-exact-symbol-input", "macho", InputPath));
+  ASSERT_FALSE(llvm::sys::fs::createTemporaryFile(
+      "neverd-arm32-macho-exact-symbol-output", "macho", OutputPath));
+  llvm::FileRemover RemoveInput(InputPath);
+  llvm::FileRemover RemoveOutput(OutputPath);
+  ASSERT_TRUE(writeFile(InputPath, Fixture.Binary));
+
+  llvm::LLVMContext Context;
+  auto Module = makeARM32TransactionModule(Context);
+  MachOPatcher Patcher;
+  PatchResult Result = Patcher.patch(
+      InputPath.str().str(), OutputPath.str().str(), *Module, Arch::ARM);
+
+  EXPECT_TRUE(Result.Success);
+  EXPECT_EQ(readFile(InputPath), Fixture.Binary);
+  EXPECT_GT(readFile(OutputPath).size(), Fixture.Binary.size());
 }
 
 TEST(MachOARM32Transaction, PartialFrameDFailureLeavesInputAndOutputUnchanged) {

--- a/unittests/lift/eh/MachOCompactUnwindPatchTests.cpp
+++ b/unittests/lift/eh/MachOCompactUnwindPatchTests.cpp
@@ -991,9 +991,9 @@ constexpr uint32_t kTransactionDataSegmentSize = 0x4000;
 constexpr uint32_t kTransactionLinkeditOff = 0xc000;
 constexpr uint32_t kTransactionLinkeditSize = 0x100;
 constexpr uint32_t kTransactionSymtabOff = kTransactionLinkeditOff;
-constexpr uint32_t kTransactionStringTableOff = kTransactionLinkeditOff + 0x20;
+constexpr uint32_t kTransactionStringTableOff = kTransactionLinkeditOff + 0x40;
 constexpr uint32_t kTransactionIndirectTableOff =
-    kTransactionLinkeditOff + 0x40;
+    kTransactionLinkeditOff + 0x80;
 constexpr uint64_t kTransactionFunctionVA = kImageBase + kTransactionTextOff;
 constexpr uint64_t kTransactionPersonalityVA = kTransactionFunctionVA + 0x10;
 constexpr uint64_t kTransactionMayThrowVA = kTransactionFunctionVA + 0x20;
@@ -1122,10 +1122,15 @@ makeMachOPatchTransactionFixture(size_t CompactCapacity) {
   Symtab->cmd = LC_SYMTAB;
   Symtab->cmdsize = SymtabCommandSize;
   Symtab->symoff = kTransactionSymtabOff;
-  Symtab->nsyms = 1;
+  Symtab->nsyms = 3;
   Symtab->stroff = kTransactionStringTableOff;
-  constexpr char PersonalityStringTable[] = "\0_test_personality";
-  Symtab->strsize = sizeof(PersonalityStringTable);
+  constexpr char SymbolStringTable[] =
+      "\0_test_personality\0may_throw\0_Unwind_Resume";
+  constexpr uint32_t MayThrowStringOffset = 19;
+  constexpr uint32_t UnwindResumeStringOffset = 29;
+  static_assert(SymbolStringTable[MayThrowStringOffset] == 'm');
+  static_assert(SymbolStringTable[UnwindResumeStringOffset] == '_');
+  Symtab->strsize = sizeof(SymbolStringTable);
 
   Command += SymtabCommandSize;
   auto *Dysymtab = reinterpret_cast<dysymtab_command *>(Command);
@@ -1155,8 +1160,22 @@ makeMachOPatchTransactionFixture(size_t CompactCapacity) {
   PersonalitySymbol->n_sect = NO_SECT;
   PersonalitySymbol->n_desc = 0;
   PersonalitySymbol->n_value = 0;
+  auto *MayThrowSymbol = PersonalitySymbol + 1;
+  MayThrowSymbol->n_strx = MayThrowStringOffset;
+  MayThrowSymbol->n_type =
+      static_cast<uint8_t>(static_cast<uint8_t>(N_SECT) | N_EXT);
+  MayThrowSymbol->n_sect = 1;
+  MayThrowSymbol->n_desc = 0;
+  MayThrowSymbol->n_value = kTransactionMayThrowVA;
+  auto *UnwindResumeSymbol = PersonalitySymbol + 2;
+  UnwindResumeSymbol->n_strx = UnwindResumeStringOffset;
+  UnwindResumeSymbol->n_type =
+      static_cast<uint8_t>(static_cast<uint8_t>(N_SECT) | N_EXT);
+  UnwindResumeSymbol->n_sect = 1;
+  UnwindResumeSymbol->n_desc = 0;
+  UnwindResumeSymbol->n_value = kTransactionUnwindResumeVA;
   std::memcpy(Fixture.Binary.data() + kTransactionStringTableOff,
-              PersonalityStringTable, sizeof(PersonalityStringTable));
+              SymbolStringTable, sizeof(SymbolStringTable));
   llvm::support::endian::write32le(
       Fixture.Binary.data() + kTransactionIndirectTableOff, 0);
   llvm::support::endian::write32le(


### PR DESCRIPTION
## Summary
- make Mach-O rewrite fixtures publish the generated callee and unwind-resume symbols consumed by the authenticated resolver
- distinguish genuinely ambiguous underscore aliases from exact-name precedence
- clarify the cross-Darwin DWARF fallback contract used by Mach-O rewrite transactions

## Test plan
- [x] Build `NeverDLiftTests`
- [x] Run all 9 `MachOARM32Transaction` tests
- [x] Run all 8 `MachOPatchTransaction` tests
- [ ] Let CI cover Linux, macOS, and Windows build profiles