### PR TITLE
feat(eh): keep Ada and D Itanium type tables opaque

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
         shell: bash
         run: |
           missing=0
-          for line in windows-eh rust-eh go-eh cxx-itanium-eh objc-eh; do
+          for line in windows-eh rust-eh go-eh cxx-itanium-eh objc-eh ada-d-eh; do
             manifest="unittests/corpus/manifests/$line.json"
             if [[ ! -f "$manifest" ]]; then
               echo "missing $manifest" >&2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,10 +198,11 @@ set(NEVERD_HAVE_RUST_EH_CORPUS OFF)
 set(NEVERD_HAVE_GO_EH_CORPUS OFF)
 set(NEVERD_HAVE_CXX_ITANIUM_EH_CORPUS OFF)
 set(NEVERD_HAVE_OBJC_EH_CORPUS OFF)
+set(NEVERD_HAVE_ADA_D_EH_CORPUS OFF)
 if(NEVERD_ENABLE_BINARY_CORPUS_TESTS)
     get_filename_component(NEVERD_BINARY_CORPUS_ROOT
         "${NEVERD_BINARY_CORPUS_ROOT}" ABSOLUTE)
-    foreach(_corpus_line windows-eh rust-eh go-eh cxx-itanium-eh objc-eh)
+    foreach(_corpus_line windows-eh rust-eh go-eh cxx-itanium-eh objc-eh ada-d-eh)
         string(REPLACE "-" "_" _corpus_slug "${_corpus_line}")
         string(TOUPPER "${_corpus_slug}" _corpus_slug)
         set(_corpus_manifest
@@ -219,7 +220,8 @@ if(NEVERD_ENABLE_BINARY_CORPUS_TESTS)
        NOT NEVERD_HAVE_RUST_EH_CORPUS AND
        NOT NEVERD_HAVE_GO_EH_CORPUS AND
        NOT NEVERD_HAVE_CXX_ITANIUM_EH_CORPUS AND
-       NOT NEVERD_HAVE_OBJC_EH_CORPUS)
+       NOT NEVERD_HAVE_OBJC_EH_CORPUS AND
+       NOT NEVERD_HAVE_ADA_D_EH_CORPUS)
         message(FATAL_ERROR
             "NEVERD_ENABLE_BINARY_CORPUS_TESTS requires at least one manifest "
             "under ${NEVERD_BINARY_CORPUS_ROOT}/manifests; "

--- a/docs/architecture.ar.md
+++ b/docs/architecture.ar.md
@@ -325,6 +325,14 @@ pipeline لإعادة الكتابة من طرف إلى طرف تغطي كل ا�
 أن يفشل أي encoding غير مدعوم أو متطلبات registration/layout غير محلولة قبل
 تعديل الخرج؛ ولا يجوز وصف الدعم الجزئي الحالي بأنه إغلاق كامل لمسار الاستثناءات.
 
+التعرف على personality من نوع Itanium لـ Ada أو D ليس دعمًا لاستثناءات Ada أو
+D. سجلات LSDA ذات شكل العنوان من GNAT وGDC وDMD وLDC قابلة للتحليل؛ وتبقى خانات
+type-table غير شفافة (`Exception_Id` / `Exception_Data` في GNAT و`ClassInfo`
+في D) ولا تُتبع أبدًا على أنها `std::type_info`. تعيد البناء الأصلي إصدار
+`personality` في LLVM مع بنود `invoke`/`landingpad` ذات شكل العنوان. حالة
+corpus-proven ادعاء منفصل ولا تُستنتج من التعرف على personality أو من lowering
+الأصلي.
+
 ## خريطة المكونات
 
 كل مكوّن أرشيف ثابت ينشئه `add_neverd_component_library`. يسرد الجدول تبعيات

--- a/docs/architecture.de.md
+++ b/docs/architecture.de.md
@@ -387,6 +387,15 @@ Registrierungs-/Layoutanforderungen müssen vor jeder Ausgabemutation scheitern;
 die vorhandene Teilunterstützung darf nicht als vollständiger Ausnahmeabschluss
 bezeichnet werden.
 
+Eine erkannte Ada- oder D-Itanium-Personality ist noch keine Ada- oder
+D-Ausnahmeunterstützung. Address-Form-LSDAs von GNAT, GDC, DMD und LDC sind
+parsebar; Type-Table-Slots bleiben undurchsichtig (`Exception_Id` /
+`Exception_Data` bei GNAT, `ClassInfo` bei D) und werden niemals als
+`std::type_info` verfolgt. Die native Rekonstruktion emittiert LLVM
+`personality` sowie Address-Form-`invoke`/`landingpad`-Klauseln. Der Status
+corpus-proven ist eine eigene Aussage und folgt weder aus der
+Personality-Erkennung noch aus dem nativen Lowering.
+
 ## Komponentenübersicht
 
 Jede Komponente ist ein von `add_neverd_component_library` erzeugtes statisches

--- a/docs/architecture.es.md
+++ b/docs/architecture.es.md
@@ -381,6 +381,15 @@ requisitos de registro/layout no resueltos deben fallar antes de modificar la
 salida; el soporte parcial existente no debe presentarse como cierre completo
 de excepciones.
 
+Reconocer una personalidad Itanium de Ada o D no es soporte de excepciones Ada
+o D. Las LSDA en forma de dirección de GNAT, GDC, DMD y LDC son analizables; las
+entradas de type-table permanecen opacas (`Exception_Id` / `Exception_Data` en
+GNAT, `ClassInfo` en D) y nunca se siguen como `std::type_info`. La
+reconstrucción nativa emite `personality` de LLVM más cláusulas
+`invoke`/`landingpad` en forma de dirección. El estado corpus-proven es una
+afirmación distinta y no se deduce del reconocimiento de personalidad ni del
+lowering nativo.
+
 ## Mapa de componentes
 
 Cada componente es un archivo estático creado por

--- a/docs/architecture.fr.md
+++ b/docs/architecture.fr.md
@@ -388,6 +388,15 @@ pris en charge ou des exigences de registration/layout non résolues doivent
 échouer avant toute mutation de la sortie ; les capacités partielles existantes
 ne doivent pas être présentées comme une couverture complète des exceptions.
 
+Reconnaître une personnalité Itanium Ada ou D n’est pas une prise en charge des
+exceptions Ada ou D. Les LSDA address-form de GNAT, GDC, DMD et LDC sont
+analysables ; les emplacements de type-table restent opaques (`Exception_Id` /
+`Exception_Data` pour GNAT, `ClassInfo` pour D) et ne sont jamais suivis comme
+`std::type_info`. La reconstruction native émet `personality` LLVM plus des
+clauses `invoke`/`landingpad` en forme d’adresse. Le statut corpus-proven est
+une affirmation distincte et ne découle ni de la reconnaissance de personnalité
+ni du lowering natif.
+
 ## Carte des composants
 
 Chaque composant est une archive statique créée par

--- a/docs/architecture.it.md
+++ b/docs/architecture.it.md
@@ -382,6 +382,15 @@ requisiti di registration/layout non risolti devono fallire prima di modificare
 l’output; il supporto parziale esistente non deve essere descritto come chiusura
 completa delle eccezioni.
 
+Riconoscere una personality Itanium Ada o D non è supporto delle eccezioni Ada
+o D. Le LSDA in forma di indirizzo di GNAT, GDC, DMD e LDC sono analizzabili; gli
+slot della type-table restano opachi (`Exception_Id` / `Exception_Data` per
+GNAT, `ClassInfo` per D) e non vengono mai seguiti come `std::type_info`. La
+ricostruzione nativa emette `personality` LLVM più clausole
+`invoke`/`landingpad` in forma di indirizzo. Lo stato corpus-proven è un’affermazione
+distinta e non è implicato dal riconoscimento della personality né dal lowering
+nativo.
+
 ## Mappa dei componenti
 
 Ogni componente è un archivio statico creato da

--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -331,6 +331,14 @@ PE、ELF、Mach-O にはそれぞれ format 固有の例外 component があり�
 しなければなりません。既存の部分的な format 対応を完全な例外処理の閉路と表現しては
 なりません。
 
+Ada または D の Itanium personality を認識することは、Ada/D 例外のサポートではあり
+ません。GNAT、GDC、DMD、LDC の address-form LSDA は解析可能です。type-table の
+スロットは不透明なまま（GNAT は `Exception_Id` / `Exception_Data`、D は
+`ClassInfo`）であり、`std::type_info` として辿ることはありません。native
+reconstruction は LLVM の `personality` と address-form の `invoke`/`landingpad`
+節を出力します。corpus-proven は別の主張であり、personality 認識や native
+lowering から導いてはなりません。
+
 ## コンポーネントマップ
 
 各コンポーネントは `add_neverd_component_library` が作成する静的アーカイブです。

--- a/docs/architecture.ko.md
+++ b/docs/architecture.ko.md
@@ -315,6 +315,13 @@ exception type을 포괄하는 end-to-end rewrite pipeline을 아직 공개하�
 않는 encoding 또는 해결되지 않은 registration/layout 요구 사항은 출력 변경 전에
 실패해야 하며, 현재의 부분적인 format 지원을 완전한 예외 재작성 폐쇄로 표현하면 안 됩니다.
 
+Ada 또는 D Itanium personality를 인식하는 것은 Ada/D 예외 지원이 아닙니다. GNAT,
+GDC, DMD, LDC의 address-form LSDA는 파싱할 수 있습니다. type-table 슬롯은 불투명하게
+유지되며(GNAT는 `Exception_Id` / `Exception_Data`, D는 `ClassInfo`)
+`std::type_info`로 따라가지 않습니다. native reconstruction은 LLVM `personality`와
+address-form `invoke`/`landingpad` 절을 방출합니다. corpus-proven은 별도의 주장이며
+personality 인식이나 native lowering에서 추론하면 안 됩니다.
+
 ## 구성 요소 맵
 
 각 구성 요소는 `add_neverd_component_library`가 만드는 정적 archive입니다. 표에는

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -351,6 +351,14 @@ pipeline. Unsupported encodings or unresolved registration/layout requirements
 must fail before output mutation; existing partial format support must not be
 described as full exception closure.
 
+Recognizing an Ada or D Itanium personality is not Ada or D exception support.
+GNAT, GDC, DMD, and LDC address-form LSDAs are parseable; type-table slots stay
+opaque (`Exception_Id` / `Exception_Data` for GNAT, `ClassInfo` for D) and are
+never followed as `std::type_info`. Native reconstruction emits LLVM
+`personality` plus address-form `invoke`/`landingpad` clauses. Corpus-proven
+status is a separate claim and is not implied by personality recognition or
+native lowering.
+
 ## Component map
 
 Every component is a static archive created by `add_neverd_component_library`.

--- a/docs/architecture.ru.md
+++ b/docs/architecture.ru.md
@@ -372,6 +372,14 @@ architecture, pointer width и byte order; compact-unwind DWARF binding откл
 registration/layout должны завершаться ошибкой до изменения вывода; имеющуюся
 частичную поддержку форматов нельзя описывать как полное замыкание исключений.
 
+Распознать Itanium-personality Ada или D — ещё не поддержка исключений Ada или
+D. Address-form LSDA от GNAT, GDC, DMD и LDC разбираемы; слоты type-table
+остаются непрозрачными (`Exception_Id` / `Exception_Data` у GNAT, `ClassInfo`
+у D) и никогда не интерпретируются как `std::type_info`. Нативная реконструкция
+выдаёт LLVM `personality` и address-form предложения `invoke`/`landingpad`.
+Статус corpus-proven — отдельное утверждение и не следует ни из распознавания
+personality, ни из нативного lowering.
+
 ## Карта компонентов
 
 Каждый компонент — статический архив, созданный

--- a/docs/architecture.zh-CN.md
+++ b/docs/architecture.zh-CN.md
@@ -269,6 +269,13 @@ PE、ELF 与 Mach-O 各自具备格式特定的异常组件，但 NeverD 尚未�
 所有异常类型的端到端重写流水线。不支持的 encoding 或未解析的注册/layout 要求必须
 在修改输出前失败；现有的局部格式能力不能描述为异常重写已经完全闭环。
 
+识别 Ada 或 D 的 Itanium personality 并不等于支持 Ada 或 D 异常。GNAT、GDC、DMD
+与 LDC 的 address-form LSDA 可解析；type-table 槽位保持不透明（GNAT 为
+`Exception_Id` / `Exception_Data`，D 为 `ClassInfo`），且绝不会按
+`std::type_info` 解引用。原生重建会发出 LLVM `personality` 以及 address-form 的
+`invoke`/`landingpad` 子句。corpus-proven 是另一层声明，不能由 personality 识别
+或原生 lowering 自行推出。
+
 ## 组件映射
 
 每个组件都是由 `add_neverd_component_library` 创建的静态归档。下表列出重要的

--- a/docs/architecture.zh-TW.md
+++ b/docs/architecture.zh-TW.md
@@ -272,6 +272,13 @@ PE、ELF 與 Mach-O 各自具備格式特定的例外元件，但 NeverD 尚未�
 所有例外類型的端到端重寫流水線。不支援的 encoding 或未解析的註冊/layout 要求必須
 在修改輸出前失敗；現有的局部格式能力不能描述為例外重寫已完全閉環。
 
+辨識 Ada 或 D 的 Itanium personality 並不等於支援 Ada 或 D 例外。GNAT、GDC、DMD
+與 LDC 的 address-form LSDA 可解析；type-table 槽位保持不透明（GNAT 為
+`Exception_Id` / `Exception_Data`，D 為 `ClassInfo`），且絕不會依
+`std::type_info` 解參考。原生重建會發出 LLVM `personality` 以及 address-form 的
+`invoke`/`landingpad` 子句。corpus-proven 是另一層聲明，不能由 personality 辨識
+或原生 lowering 自行推出。
+
 ## 元件對照
 
 每個元件都是由 `add_neverd_component_library` 建立的靜態歸檔。下表列出重要的

--- a/docs/capabilities.json
+++ b/docs/capabilities.json
@@ -335,6 +335,35 @@
       }
     },
     {
+      "id": "exception.itanium.ada-d",
+      "kind": "analysis",
+      "status": "experimental",
+      "owner": "exception-rewrite",
+      "targets": [
+        "x86_64",
+        "aarch64"
+      ],
+      "docs": [
+        "docs/architecture.md"
+      ],
+      "limitations": [
+        "recognizing an Ada or D Itanium personality is not Ada or D exception support",
+        "GNAT Exception_Id/Exception_Data and D ClassInfo type-table slots stay opaque and are never followed as std::type_info",
+        "native reconstruction emits LLVM personality plus address-form invoke/landingpad clauses only; SJLJ personalities are not lowered",
+        "corpus-proven status is a separate claim and is not published by this capability"
+      ],
+      "tests": [
+        "ItaniumLSDA.KeepsAdaAndDTypeDescriptorsOpaque",
+        "ItaniumEHEmitter.PreservesAdaAndDAddressFormPersonalities"
+      ],
+      "public_surfaces": {
+        "c": [],
+        "python": [],
+        "cli": [],
+        "json": []
+      }
+    },
+    {
       "id": "llvm.semantic.synthesis-rewrite",
       "kind": "rewrite",
       "status": "supported",

--- a/docs/capabilities.json
+++ b/docs/capabilities.json
@@ -354,7 +354,10 @@
       ],
       "tests": [
         "ItaniumLSDA.KeepsAdaAndDTypeDescriptorsOpaque",
-        "ItaniumEHEmitter.PreservesAdaAndDAddressFormPersonalities"
+        "ItaniumEHEmitter.PreservesAdaAndDAddressFormPersonalities",
+        "AdaDEHCorpus.DeclaresCompleteBuildMatrix",
+        "AdaDEHCorpus.RecoversTheCallSiteGraphOnEveryCell",
+        "AdaDEHCorpus.KeepsAdaAndDTypeDescriptorsOpaque"
       ],
       "public_surfaces": {
         "c": [],

--- a/include/neverd/loader/DWARF/LSDA.h
+++ b/include/neverd/loader/DWARF/LSDA.h
@@ -35,6 +35,10 @@ struct LSDAParseRequest {
   /// End of that function, when the FDE proved one.  Zero disables the
   /// containment check rather than inventing a bound.
   va_t FunctionEnd = 0;
+  /// The routine that defines this LSDA's language contract, including what a
+  /// positive type-table entry points at.  `Unknown` and `None` keep entries
+  /// opaque rather than assuming C++ RTTI.
+  ExceptionPersonality Personality = ExceptionPersonality::None;
   /// True for the setjmp/longjmp call-site form, whose table holds call-site
   /// indices instead of addresses.
   bool IsSJLJ = false;

--- a/include/neverd/loader/ExceptionPersonality.h
+++ b/include/neverd/loader/ExceptionPersonality.h
@@ -22,6 +22,22 @@
 
 namespace neverd {
 
+/// What a positive Itanium action filter points at for one personality.
+///
+/// The LSDA byte layout is shared by several language runtimes, but the object
+/// named by a type-table slot is not.  Following every non-null entry as
+/// `std::type_info` is therefore unsafe: an Ada `Exception_Id` and a D
+/// `ClassInfo` can both contain a pointer-looking second word that would yield
+/// a convincing name from unrelated data.
+enum class ItaniumTypeTableEntryKind : uint8_t {
+  /// A `std::type_info` object or a layout-compatible Objective-C descriptor.
+  CxxRTTI,
+  /// A class-name string stored directly in the slot.
+  DirectCString,
+  /// A runtime-owned descriptor whose identity is preserved but not decoded.
+  OpaqueDescriptor,
+};
+
 /// The exact personality identity.  Two personalities that share a table
 /// schema still remain distinct enumerators whenever their run-time contract
 /// differs, because a rewriter must reproduce the contract and not merely the
@@ -267,6 +283,30 @@ inline bool isItaniumPersonality(ExceptionPersonality P) {
     return true;
   default:
     return false;
+  }
+}
+
+/// Return the language-defined interpretation of an Itanium type-table slot.
+///
+/// Unknown personalities are deliberately opaque.  The personality routine is
+/// the version tag for an LSDA; without its identity there is no evidence that
+/// a pointer in the table follows the C++ RTTI layout.
+inline ItaniumTypeTableEntryKind
+getItaniumTypeTableEntryKind(ExceptionPersonality P) {
+  switch (P) {
+  case ExceptionPersonality::GxxPersonalityV0:
+  case ExceptionPersonality::GxxPersonalitySEH0:
+  case ExceptionPersonality::GxxPersonalitySJ0:
+  case ExceptionPersonality::ObjCPersonalityV0:
+  case ExceptionPersonality::GNUstepObjCXXPersonalityV0:
+    return ItaniumTypeTableEntryKind::CxxRTTI;
+  case ExceptionPersonality::GnuObjCPersonalityV0:
+  case ExceptionPersonality::GnuObjCPersonalitySEH0:
+  case ExceptionPersonality::GnuObjCPersonalitySJ0:
+  case ExceptionPersonality::GNUstepObjCPersonalityV0:
+    return ItaniumTypeTableEntryKind::DirectCString;
+  default:
+    return ItaniumTypeTableEntryKind::OpaqueDescriptor;
   }
 }
 

--- a/include/neverd/loader/LanguageEHItanium.h
+++ b/include/neverd/loader/LanguageEHItanium.h
@@ -16,6 +16,7 @@
 #define NEVERD_LOADER_LANGUAGEEHITANIUM_H
 
 #include "neverd/loader/ExceptionCommon.h"
+#include "neverd/loader/ExceptionPersonality.h"
 
 #include <cstdint>
 #include <optional>
@@ -78,18 +79,23 @@ struct ItaniumCallSite {
   uint64_t NativeActionRecord = 0;
 };
 
-/// One type-table slot.  `TypeInfoVA` is zero for the catch-all slot, which
-/// the ABI spells as a null `std::type_info*`.
+/// One type-table slot.  `TypeInfoVA` is zero for the catch-all slot.
+///
+/// The field names retain their established ABI-neutral shape, but the object
+/// they identify is defined by \ref ItaniumEHInfo::TypeTableEntryKind: C++
+/// uses `std::type_info`, Ada uses an `Exception_Id`, D uses `ClassInfo`, and
+/// GNU Objective-C stores a class-name string directly.
 struct ItaniumTypeEntry {
   /// 1-based index as named by a positive action filter.
   uint64_t Index = 0;
   va_t TypeInfoVA = 0;
-  /// For an indirect encoding, the address of the cell the `std::type_info*`
+  /// For an indirect encoding, the address of the cell the descriptor pointer
   /// was loaded through.  A cell bound at load time holds a placeholder in the
-  /// file image, so this is what lets the RTTI be named from the binding.
+  /// file image, so this is what preserves its identity from the binding.
   va_t TypeInfoSlotVA = 0;
-  /// Mangled RTTI symbol (`_ZTI...`) or the `std::type_info::__type_name`
-  /// string, whichever could be proven; empty when neither could be.
+  /// Proven symbol or language-defined name.  Only `CxxRTTI` entries are
+  /// followed to a `std::type_info::__type_name`; opaque descriptors are never
+  /// dereferenced to manufacture one.
   std::string TypeName;
   bool IsCatchAll = false;
 };
@@ -106,6 +112,9 @@ struct ItaniumExceptionSpec {
 /// A fully decoded `.gcc_except_table` record.
 struct ItaniumEHInfo {
   va_t LSDAVA = 0;
+  /// How this personality interprets each positive type-table entry.
+  ItaniumTypeTableEntryKind TypeTableEntryKind =
+      ItaniumTypeTableEntryKind::OpaqueDescriptor;
   /// Encoding and resolved base for landing-pad addresses.
   uint8_t LandingPadBaseEncoding = 0xFF;
   va_t LandingPadBase = 0;

--- a/lib/backend/llvm/eh/MedLLVMNativeItaniumEH.cpp
+++ b/lib/backend/llvm/eh/MedLLVMNativeItaniumEH.cpp
@@ -67,6 +67,18 @@ const char *itaniumPersonalitySymbol(ExceptionPersonality P) {
     return "__objc_personality_v0";
   case ExceptionPersonality::RustEhPersonality:
     return "rust_eh_personality";
+  case ExceptionPersonality::GnatPersonalityV0:
+    return "__gnat_personality_v0";
+  case ExceptionPersonality::GnatPersonalitySEH0:
+    return "__gnat_personality_seh0";
+  case ExceptionPersonality::DmdPersonalityV0:
+    return "__dmd_personality_v0";
+  case ExceptionPersonality::DRuntimeEhPersonality:
+    return "_d_eh_personality";
+  case ExceptionPersonality::GdcPersonalityV0:
+    return "__gdc_personality_v0";
+  case ExceptionPersonality::GdcPersonalitySEH0:
+    return "__gdc_personality_seh0";
   default:
     return nullptr;
   }
@@ -458,7 +470,9 @@ bool MedLLVMEmitter::emitNativeItaniumEH(
         Entry->TypeInfoSlotVA != 0 ? Entry->TypeInfoSlotVA : Entry->TypeInfoVA};
     llvm::StringRef DecodedName(Entry->TypeName);
     const bool IsRTTISymbol =
-        DecodedName.starts_with("_ZTI") || DecodedName.starts_with("__ZTI");
+        getItaniumTypeTableEntryKind(EH.Personality) ==
+            ItaniumTypeTableEntryKind::CxxRTTI &&
+        (DecodedName.starts_with("_ZTI") || DecodedName.starts_with("__ZTI"));
     const std::string Name =
         Identity.IsSlot ? makeNdDataSymbol(Identity.Address)
                         : (IsRTTISymbol ? Entry->TypeName
@@ -495,7 +509,9 @@ bool MedLLVMEmitter::emitNativeItaniumEH(
       return Mapped;
     llvm::StringRef DecodedName(Entry.TypeName);
     const bool IsRTTISymbol =
-        DecodedName.starts_with("_ZTI") || DecodedName.starts_with("__ZTI");
+        getItaniumTypeTableEntryKind(EH.Personality) ==
+            ItaniumTypeTableEntryKind::CxxRTTI &&
+        (DecodedName.starts_with("_ZTI") || DecodedName.starts_with("__ZTI"));
     std::string Name =
         IsRTTISymbol ? Entry.TypeName : makeNdDataSymbol(Entry.TypeInfoVA);
     llvm::GlobalVariable *GV = Mod->getNamedGlobal(Name);

--- a/lib/loader/COFF/eh/COFFException.cpp
+++ b/lib/loader/COFF/eh/COFFException.cpp
@@ -49,6 +49,7 @@ bool parseMinGWLSDA(ExceptionFunction &F, const BinaryImage &Img) {
   Req.LSDAVA = F.HandlerDataVA;
   Req.FunctionStart = F.CodeRange.Begin;
   Req.FunctionEnd = F.CodeRange.End;
+  Req.Personality = F.Personality;
   Req.MaxRecords = detail::MaxLanguageRecords;
 
   dwarf_eh::PointerBases Bases;

--- a/lib/loader/DWARF/ItaniumEH.cpp
+++ b/lib/loader/DWARF/ItaniumEH.cpp
@@ -207,6 +207,7 @@ void parseItaniumExceptions(BinaryImage &Img) {
       Req.LSDAVA = FDE.LSDAVA;
       Req.FunctionStart = F.CodeRange.Begin;
       Req.FunctionEnd = F.CodeRange.End;
+      Req.Personality = F.Personality;
       Req.IsSJLJ = isSJLJPersonality(F.Personality);
       PointerBases LSDABases = Bases;
       LSDABases.Func = F.CodeRange.Begin;
@@ -268,6 +269,7 @@ bool refreshItaniumLanguageData(const BinaryImage &Img,
   Req.LSDAVA = Function.HandlerDataVA;
   Req.FunctionStart = Function.CodeRange.Begin;
   Req.FunctionEnd = Function.CodeRange.End;
+  Req.Personality = Function.Personality;
   Req.IsSJLJ = isSJLJPersonality(Function.Personality);
 
   PointerBases Bases = computeBases(Img);

--- a/lib/loader/DWARF/LSDA.cpp
+++ b/lib/loader/DWARF/LSDA.cpp
@@ -52,6 +52,25 @@ size_t mappedBytesAt(const BinaryImage &Img, va_t Address, size_t Want) {
   return Lo;
 }
 
+std::string readMappedCString(const BinaryImage &Img, va_t Address) {
+  if (Address == 0)
+    return {};
+  const size_t Available = mappedBytesAt(Img, Address, kMaxTypeNameBytes);
+  if (Available == 0)
+    return {};
+  const uint8_t *Bytes = Img.readVA(Address, Available);
+  if (!Bytes)
+    return {};
+  size_t Length = 0;
+  while (Length < Available && Bytes[Length] != 0)
+    ++Length;
+  // An unterminated run is not a C string; refusing it keeps arbitrary
+  // descriptor bytes from becoming a reported language type name.
+  if (Length == 0 || Length == Available)
+    return {};
+  return std::string(reinterpret_cast<const char *>(Bytes), Length);
+}
+
 } // namespace
 
 std::string readItaniumTypeName(const BinaryImage &Img, va_t TypeInfoVA) {
@@ -68,23 +87,7 @@ std::string readItaniumTypeName(const BinaryImage &Img, va_t TypeInfoVA) {
     return {};
   const va_t NameVA = PtrSize == 4 ? va_t(readLE<uint32_t>(NameSlot))
                                    : va_t(readLE<uint64_t>(NameSlot));
-  if (NameVA == 0)
-    return {};
-
-  const size_t Available = mappedBytesAt(Img, NameVA, kMaxTypeNameBytes);
-  if (Available == 0)
-    return {};
-  const uint8_t *Bytes = Img.readVA(NameVA, Available);
-  if (!Bytes)
-    return {};
-  size_t Length = 0;
-  while (Length < Available && Bytes[Length] != 0)
-    ++Length;
-  // An unterminated run is not a C string; refusing it keeps a pointer into
-  // arbitrary data from being reported as a type name.
-  if (Length == 0 || Length == Available)
-    return {};
-  return std::string(reinterpret_cast<const char *>(Bytes), Length);
+  return readMappedCString(Img, NameVA);
 }
 
 LSDAParseResult parseLSDA(const BinaryImage &Img, const LSDAParseRequest &Req,
@@ -115,6 +118,8 @@ LSDAParseResult parseLSDA(const BinaryImage &Img, const LSDAParseRequest &Req,
 
   ItaniumEHInfo Info;
   Info.LSDAVA = Req.LSDAVA;
+  Info.TypeTableEntryKind =
+      getItaniumTypeTableEntryKind(Req.Personality);
   Info.IsCallSiteAddressForm = !Req.IsSJLJ;
 
   size_t Cursor = 0;
@@ -410,8 +415,13 @@ LSDAParseResult parseLSDA(const BinaryImage &Img, const LSDAParseRequest &Req,
         // load time is also null there, but it is a real type: the binding
         // names it, so only an unbound null is the ABI's `catch (...)`.
         Entry.IsCatchAll = TypeInfo == 0 && IndirectSlot == 0;
-        if (TypeInfo != 0)
+        if (TypeInfo != 0 &&
+            Info.TypeTableEntryKind == ItaniumTypeTableEntryKind::CxxRTTI)
           Entry.TypeName = readItaniumTypeName(Img, TypeInfo);
+        else if (TypeInfo != 0 &&
+                 Info.TypeTableEntryKind ==
+                     ItaniumTypeTableEntryKind::DirectCString)
+          Entry.TypeName = readMappedCString(Img, TypeInfo);
         if (Entry.TypeName.empty()) {
           Entry.TypeName = resolveRoutineName(Img, TypeInfo, IndirectSlot);
           Entry.IsCatchAll = Entry.IsCatchAll && Entry.TypeName.empty();

--- a/lib/loader/ELF/ARMEHABI.cpp
+++ b/lib/loader/ELF/ARMEHABI.cpp
@@ -273,6 +273,7 @@ void parseARMEHABIExceptions(BinaryImage &Img) {
           Req.LSDAVA = Table.HandlerDataVA;
           Req.FunctionStart = F.CodeRange.Begin;
           Req.FunctionEnd = F.CodeRange.End;
+          Req.Personality = F.Personality;
           dwarf_eh::PointerBases LSDABases = Bases;
           LSDABases.Func = F.CodeRange.Begin;
 

--- a/lib/loader/MachO/MachOExceptions.cpp
+++ b/lib/loader/MachO/MachOExceptions.cpp
@@ -64,6 +64,7 @@ void attachLSDA(const BinaryImage &Img, const dwarf_eh::PointerBases &Bases,
   Req.LSDAVA = LSDAVA;
   Req.FunctionStart = F.CodeRange.Begin;
   Req.FunctionEnd = F.CodeRange.End;
+  Req.Personality = F.Personality;
   Req.IsSJLJ = isSJLJPersonality(F.Personality);
   dwarf_eh::PointerBases LSDABases = Bases;
   LSDABases.Func = F.CodeRange.Begin;

--- a/scripts/audit_ci_test_inventory.py
+++ b/scripts/audit_ci_test_inventory.py
@@ -20,6 +20,7 @@ PATCH_LABEL = "NeverDPatchFullTests"
 # when the configure step was told to look for the corpus, and each reads
 # several hundred real binaries that nothing else in the tree covers.
 CORPUS_LABELS = (
+    "NeverDAdaDEHCorpusTests",
     "NeverDCxxItaniumEHCorpusTests",
     "NeverDGoEHCorpusTests",
     "NeverDObjCEHCorpusTests",
@@ -122,8 +123,14 @@ def audit_inventory(
 
     records = parse_inventory(document)
     names = [record.name for record in records]
+    # Focused binaries deliberately compile the same TU as a large suite so
+    # one host can skip the suite and still run the cases.  Identity is
+    # therefore (name, labels), not the gtest name alone.
+    identities = [(record.name, record.labels) for record in records]
     duplicates = sorted(
-        name for name, count in Counter(names).items() if count > 1
+        name
+        for (name, _labels), count in Counter(identities).items()
+        if count > 1
     )
     if duplicates:
         preview = ", ".join(repr(name) for name in duplicates[:10])
@@ -178,8 +185,7 @@ def audit_inventory(
         if not any(excluded_pattern.search(label) for label in record.labels)
     )
     selected_names = tuple(sorted(record.name for record in selected))
-    selected_name_set = set(selected_names)
-    if not selected_name_set:
+    if not selected:
         raise InventoryError(f"profile {profile!r} selected zero tests")
 
     heavy_sets = {
@@ -188,19 +194,20 @@ def audit_inventory(
     }
     expected_owners = PROFILE_HEAVY_OWNERS[profile]
     for label, owned_names in heavy_sets.items():
-        selected_owned = selected_name_set & owned_names
+        selected_owned = {record.name for record in selected if label in record.labels}
         if label in expected_owners and selected_owned != owned_names:
             raise InventoryError(f"profile {profile!r} does not select all of {label}")
         if label not in expected_owners and selected_owned:
             raise InventoryError(f"profile {profile!r} unexpectedly selects {label}")
 
-    excluded_names = set(names) - selected_name_set
+    selected_set = set(selected)
+    excluded = {record for record in records if record not in selected_set}
     expression_excluded = {
-        record.name
+        record
         for record in records
         if any(excluded_pattern.search(label) for label in record.labels)
     }
-    if excluded_names != expression_excluded:
+    if excluded != expression_excluded:
         raise InventoryError("selected inventory is not the exact label set difference")
 
     return AuditResult(
@@ -210,7 +217,7 @@ def audit_inventory(
         semantic_count=len(semantic_names),
         patch_count=len(patch_names),
         selected_count=len(selected),
-        excluded_count=len(excluded_names),
+        excluded_count=len(excluded),
         selected_names=selected_names,
     )
 

--- a/scripts/check_capabilities.py
+++ b/scripts/check_capabilities.py
@@ -51,6 +51,7 @@ REQUIRED_CAPABILITY_IDS = frozenset(
         "debug.hardware",
         "debug.local",
         "debug.remote",
+        "exception.itanium.ada-d",
         "exception.rewrite.end-to-end",
         "llvm.semantic.synthesis-rewrite",
         "semantic.mba.derivation",

--- a/scripts/check_docs_i18n.py
+++ b/scripts/check_docs_i18n.py
@@ -272,6 +272,10 @@ class RepositoryView:
         return (REPO_ROOT / relative_path).exists()
 
 
+def display_path(path: Path) -> str:
+    return path.as_posix()
+
+
 def report(errors: list[str], message: str) -> None:
     errors.append(message)
 
@@ -285,7 +289,7 @@ def require_tokens(
     text = view.read_text(path)
     for token in tokens:
         if token not in text:
-            report(errors, f"{path}: missing required token {token!r}")
+            report(errors, f"{display_path(path)}: missing required token {token!r}")
 
 
 def validate_architecture_semantics(errors: list[str], view: RepositoryView) -> None:
@@ -296,8 +300,8 @@ def validate_architecture_semantics(errors: list[str], view: RepositoryView) -> 
                 if token not in text:
                     report(
                         errors,
-                        f"{path}: architecture capability {capability_id!r} "
-                        f"missing required token {token!r}",
+                        f"{display_path(path)}: architecture capability "
+                        f"{capability_id!r} missing required token {token!r}",
                     )
 
 
@@ -380,10 +384,17 @@ def validate_links(
             try:
                 destination_relative = destination.relative_to(REPO_ROOT)
             except ValueError:
-                report(errors, f"{relative_path}: link escapes repository: {target}")
+                report(
+                    errors,
+                    f"{display_path(relative_path)}: link escapes repository: "
+                    f"{target}",
+                )
                 continue
             if not view.exists(destination_relative):
-                report(errors, f"{relative_path}: missing link target: {target}")
+                report(
+                    errors,
+                    f"{display_path(relative_path)}: missing link target: {target}",
+                )
                 continue
             if not separator or not fragment or destination.suffix.lower() != ".md":
                 continue
@@ -395,8 +406,9 @@ def validate_links(
             if decoded_fragment not in anchors:
                 report(
                     errors,
-                    f"{relative_path}: missing Markdown anchor {decoded_fragment!r} in "
-                    f"{destination.relative_to(REPO_ROOT)}",
+                    f"{display_path(relative_path)}: missing Markdown anchor "
+                    f"{decoded_fragment!r} in "
+                    f"{display_path(destination.relative_to(REPO_ROOT))}",
                 )
 
 
@@ -420,13 +432,20 @@ def validate_markdown_structure(
                 opening = None
         if opening is not None:
             _, _, line_number = opening
-            report(errors, f"{relative_path}:{line_number}: unclosed Markdown fence")
+            report(
+                errors,
+                f"{display_path(relative_path)}:{line_number}: "
+                "unclosed Markdown fence",
+            )
 
 
 def validate_matrix(errors: list[str], view: RepositoryView) -> None:
     for path in MARKDOWN_DOCS:
         if not view.exists(path):
-            report(errors, f"missing localized documentation file: {path}")
+            report(
+                errors,
+                f"missing localized documentation file: {display_path(path)}",
+            )
     if errors:
         return
 

--- a/scripts/check_docs_i18n.py
+++ b/scripts/check_docs_i18n.py
@@ -49,6 +49,13 @@ ARCHITECTURE_CAPABILITY_TOKENS = {
         "`__TEXT,__unwind_info`",
         "`__LINKEDIT`",
     ),
+    "exception.itanium.ada-d": (
+        "`Exception_Id`",
+        "`ClassInfo`",
+        "`std::type_info`",
+        "`invoke`",
+        "`landingpad`",
+    ),
 }
 GUIDE_STEMS = ("evm", "sbf")
 GUIDE_REQUIRED_TOKENS = {

--- a/scripts/check_source_provenance.py
+++ b/scripts/check_source_provenance.py
@@ -347,30 +347,37 @@ def is_allowed(path: str, rule: str) -> bool:
     return any(a.rule == rule and fnmatch(path, a.path) for a in ALLOWED)
 
 
-def tracked_files() -> list[str]:
-    """Return every file Git tracks, leaving submodules opaque."""
-
-    output = subprocess.run(
-        ["git", "ls-files", "-z"],
+def _run_git(arguments: Sequence[str]) -> str:
+    # Git emits UTF-8.  Windows Python otherwise decodes the pipe as the
+    # locale (cp1252), which cannot read a CJK architecture patch.
+    return subprocess.run(
+        ["git", *arguments],
         cwd=REPO_ROOT,
         check=True,
         capture_output=True,
         text=True,
+        encoding="utf-8",
     ).stdout
-    return [entry for entry in output.split("\0") if entry]
+
+
+def tracked_files() -> list[str]:
+    """Return every file Git tracks, leaving submodules opaque."""
+
+    return [entry for entry in _run_git(["ls-files", "-z"]).split("\0") if entry]
 
 
 def worktree_files() -> list[str]:
     """Return tracked plus pending, non-ignored files in the worktree."""
 
-    output = subprocess.run(
-        ["git", "ls-files", "--cached", "--others", "--exclude-standard", "-z"],
-        cwd=REPO_ROOT,
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout
-    return sorted({entry for entry in output.split("\0") if entry})
+    return sorted(
+        {
+            entry
+            for entry in _run_git(
+                ["ls-files", "--cached", "--others", "--exclude-standard", "-z"]
+            ).split("\0")
+            if entry
+        }
+    )
 
 
 def _scan_text(
@@ -419,13 +426,7 @@ def scan(paths: Sequence[str], rules: Sequence[Rule] | None = None) -> list[str]
 
 def _git_output(arguments: Sequence[str]) -> str:
     try:
-        return subprocess.run(
-            ["git", *arguments],
-            cwd=REPO_ROOT,
-            check=True,
-            capture_output=True,
-            text=True,
-        ).stdout
+        return _run_git(arguments)
     except (OSError, subprocess.CalledProcessError):
         raise GitScanError("Git patch inventory could not be read") from None
 

--- a/scripts/check_source_provenance.py
+++ b/scripts/check_source_provenance.py
@@ -515,6 +515,15 @@ def scan_recent_history(
     ).splitlines()
     findings: list[str] = []
     for commit in commits:
+        # A merge commit has no default diff-tree inventory, but `git show
+        # --first-parent` still prints a first-parent patch.  GitHub Actions
+        # checks out that synthetic merge for pull_request jobs.  The
+        # first-parent regular commits already carry the same text, so
+        # scanning the merge would only re-count it and trip the inventory
+        # check.
+        parents = _git_output(["rev-list", "--parents", "-n", "1", commit]).split()
+        if len(parents) > 2:
+            continue
         names = [
             entry
             for entry in _git_output(

--- a/scripts/tests/test_audit_ci_test_inventory.py
+++ b/scripts/tests/test_audit_ci_test_inventory.py
@@ -115,6 +115,23 @@ class AuditInventoryTests(unittest.TestCase):
         with self.assertRaisesRegex(InventoryError, "does not match profile"):
             self.audit("linux-semantic", r"^NeverDSemanticTests$")
 
+    def test_same_name_on_a_focused_binary_is_not_a_duplicate(self):
+        document = valid_inventory()
+        document["tests"].append(
+            {
+                "name": "semantic/a",
+                "properties": [{"name": "LABELS", "value": ["NeverDFP16ReduceTests"]}],
+            }
+        )
+        result = audit_inventory(
+            document,
+            "macos-patch",
+            r"^NeverDSemanticTests$",
+            semantic_minimum=2,
+            patch_minimum=2,
+        )
+        self.assertIn("semantic/a", result.selected_names)
+
     def test_duplicate_names_fail_with_a_bounded_diagnostic(self):
         document = valid_inventory()
         document["tests"].append(document["tests"][0])

--- a/scripts/tests/test_check_capabilities.py
+++ b/scripts/tests/test_check_capabilities.py
@@ -576,6 +576,7 @@ class RepositoryCapabilityTests(unittest.TestCase):
                 "debug.hardware": "unsupported",
                 "debug.local": "unsupported",
                 "debug.remote": "unsupported",
+                "exception.itanium.ada-d": "experimental",
                 "exception.rewrite.end-to-end": "unsupported",
                 "semantic.mba.derivation": "supported",
                 "semantic.synthesis.candidate": "supported",
@@ -590,6 +591,7 @@ class RepositoryCapabilityTests(unittest.TestCase):
             "debug.hardware": no_surfaces,
             "debug.local": no_surfaces,
             "debug.remote": no_surfaces,
+            "exception.itanium.ada-d": no_surfaces,
             "exception.rewrite.end-to-end": no_surfaces,
             "semantic.mba.derivation": {
                 "c": ["neverd_simplify_expr"],

--- a/scripts/tests/test_check_docs_i18n.py
+++ b/scripts/tests/test_check_docs_i18n.py
@@ -143,7 +143,7 @@ class LocalizedDocumentationMatrixTests(unittest.TestCase):
                         self.assertEqual(
                             errors,
                             [
-                                f"{path}: architecture capability "
+                                f"{path.as_posix()}: architecture capability "
                                 f"{capability_id!r} missing required token "
                                 f"{missing_token!r}"
                             ],
@@ -161,7 +161,8 @@ class LocalizedDocumentationMatrixTests(unittest.TestCase):
         self.assertEqual(
             errors,
             [
-                f"{path}: architecture capability 'translation.runtime-contract' "
+                f"{path.as_posix()}: architecture capability "
+                f"'translation.runtime-contract' "
                 f"missing required token {token!r}"
             ],
         )

--- a/scripts/tests/test_check_docs_i18n.py
+++ b/scripts/tests/test_check_docs_i18n.py
@@ -105,6 +105,13 @@ class LocalizedDocumentationMatrixTests(unittest.TestCase):
                 "`__TEXT,__unwind_info`",
                 "`__LINKEDIT`",
             ),
+            "exception.itanium.ada-d": (
+                "`Exception_Id`",
+                "`ClassInfo`",
+                "`std::type_info`",
+                "`invoke`",
+                "`landingpad`",
+            ),
         }
         architecture_paths = (
             Path("docs/architecture.md"),

--- a/scripts/tests/test_check_source_provenance.py
+++ b/scripts/tests/test_check_source_provenance.py
@@ -375,6 +375,28 @@ class ProvenanceOfThisRepositoryTests(unittest.TestCase):
             self.assertEqual(len(findings), 1)
             self.assertIn("source.cpp@", findings[0])
 
+    def test_git_output_decodes_patches_as_utf8(self) -> None:
+        with mock.patch.object(provenance.subprocess, "run") as run:
+            run.return_value = mock.Mock(stdout="diff --git a/docs/老.md b/docs/老.md\n")
+            text = provenance._git_output(["show", "HEAD"])
+        self.assertIn("老", text)
+        self.assertEqual(run.call_args.kwargs["encoding"], "utf-8")
+
+    def test_recent_history_reads_a_cjk_patch(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            subprocess.run(("git", "init", "-q"), cwd=root, check=True)
+            path = root / "note.md"
+            path.write_text("老\n", encoding="utf-8")
+            subprocess.run(("git", "add", "note.md"), cwd=root, check=True)
+            self.commit(root, "add cjk")
+            rule = ProvenanceScanTests.term_rule("private-path", "private-token")
+
+            with mock.patch.object(provenance, "REPO_ROOT", root):
+                findings = provenance.scan_recent_history(1, (rule,))
+
+            self.assertEqual(findings, [])
+
     def test_recent_history_skips_a_merge_commit(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/scripts/tests/test_check_source_provenance.py
+++ b/scripts/tests/test_check_source_provenance.py
@@ -375,6 +375,45 @@ class ProvenanceOfThisRepositoryTests(unittest.TestCase):
             self.assertEqual(len(findings), 1)
             self.assertIn("source.cpp@", findings[0])
 
+    def test_recent_history_skips_a_merge_commit(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            subprocess.run(("git", "init", "-q", "-b", "main"), cwd=root, check=True)
+            (root / "base.cpp").write_text("int base;\n", encoding="utf-8")
+            subprocess.run(("git", "add", "base.cpp"), cwd=root, check=True)
+            self.commit(root, "base")
+            subprocess.run(("git", "checkout", "-q", "-b", "feature"), cwd=root, check=True)
+            (root / "feature.cpp").write_text("int feature;\n", encoding="utf-8")
+            subprocess.run(("git", "add", "feature.cpp"), cwd=root, check=True)
+            self.commit(root, "feature")
+            subprocess.run(("git", "checkout", "-q", "main"), cwd=root, check=True)
+            (root / "main.cpp").write_text("int mainline;\n", encoding="utf-8")
+            subprocess.run(("git", "add", "main.cpp"), cwd=root, check=True)
+            self.commit(root, "mainline")
+            subprocess.run(
+                (
+                    "git",
+                    "-c",
+                    "user.name=NeverD Test",
+                    "-c",
+                    "user.email=test@example.invalid",
+                    "merge",
+                    "-q",
+                    "--no-ff",
+                    "-m",
+                    "merge feature",
+                    "feature",
+                ),
+                cwd=root,
+                check=True,
+            )
+            rule = ProvenanceScanTests.term_rule("private-path", "private-token")
+
+            with mock.patch.object(provenance, "REPO_ROOT", root):
+                findings = provenance.scan_recent_history(1, (rule,))
+
+            self.assertEqual(findings, [])
+
     def test_ci_fetches_and_scans_recent_history(self) -> None:
         workflow = (provenance.REPO_ROOT / ".github/workflows/ci.yml").read_text(
             encoding="utf-8"

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -127,6 +127,16 @@ if(TARGET NeverDCxxItaniumEHCorpusTests)
     COMMENT "Running the pinned C++ Itanium and ARM EHABI corpus")
 endif()
 
+if(TARGET NeverDAdaDEHCorpusTests)
+  add_custom_target(check-neverd-ada-d-eh-corpus
+    COMMAND ${CMAKE_CTEST_COMMAND} --test-dir ${CMAKE_BINARY_DIR}
+            -L ^NeverDAdaDEHCorpusTests$
+            --output-on-failure --progress -j ${_neverd_ncpu} -C $<CONFIG>
+    DEPENDS NeverDAdaDEHCorpusTests
+    USES_TERMINAL
+    COMMENT "Running the pinned Ada and D Itanium exception corpus")
+endif()
+
 if(TARGET NeverDObjCEHCorpusTests)
   add_custom_target(check-neverd-objc-eh-corpus
     COMMAND ${CMAKE_CTEST_COMMAND} --test-dir ${CMAKE_BINARY_DIR}
@@ -140,7 +150,7 @@ endif()
 # One target for every line at once, because what the corpus is for is the
 # claim that no line regressed while another was being worked on.
 set(_neverd_corpus_targets)
-foreach(_line windows-eh rust-eh go-eh cxx-itanium-eh objc-eh)
+foreach(_line windows-eh rust-eh go-eh cxx-itanium-eh objc-eh ada-d-eh)
   if(TARGET check-neverd-${_line}-corpus)
     list(APPEND _neverd_corpus_targets check-neverd-${_line}-corpus)
   endif()

--- a/unittests/lift/CMakeLists.txt
+++ b/unittests/lift/CMakeLists.txt
@@ -206,6 +206,13 @@ target_include_directories(NeverDNativeExceptionRewriteContractTests PRIVATE
   ${LLVM_INCLUDE_DIRS}
 )
 
+# NeverDIR holds function pointers into the register-name tables.  GNU ld
+# does not rescan NeverDLift after that archive, so the focused binary has
+# to name Lift again after the IR dependency is already on the line.
+target_link_libraries(NeverDNativeExceptionRewriteContractTests PRIVATE
+  NeverDLift
+)
+
 # Guards the obfuscate-then-patch barrier in isolation.  A tiny TU that links
 # the prebuilt NeverDPipeline archive (which carries SymSimplifyPass through its
 # PassIR component), so the stamp/skip contract can be pinned without rebuilding
@@ -543,6 +550,11 @@ if(TARGET neverd_shared)
     sdk/SemanticCAPIHeaderC.c
     sdk/SemanticCAPITests.cpp
   )
+  if(MSVC)
+    # File-scope _Static_assert is C11.  MSVC compiles .c as C89 unless told.
+    set_source_files_properties(sdk/SemanticCAPIHeaderC.c PROPERTIES
+      COMPILE_OPTIONS /std:c11)
+  endif()
 
   target_include_directories(NeverDSemanticCAPITests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/unittests/lift/CMakeLists.txt
+++ b/unittests/lift/CMakeLists.txt
@@ -337,6 +337,20 @@ target_link_libraries(NeverDGoEHCorpusManifestTests PRIVATE
   NeverDSupport
 )
 
+add_neverd_unittest(NeverDAdaDEHCorpusManifestTests
+  corpus/ada-d-eh/AdaDEHCorpusManifestTests.cpp
+  corpus/ada-d-eh/AdaDEHCorpusManifest.cpp
+)
+target_include_directories(NeverDAdaDEHCorpusManifestTests PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_SOURCE_DIR}/include
+  ${LLVM_INCLUDE_DIRS}
+)
+target_link_libraries(NeverDAdaDEHCorpusManifestTests PRIVATE
+  NeverDLoader
+  NeverDSupport
+)
+
 add_neverd_unittest(NeverDCxxItaniumEHCorpusManifestTests
   corpus/cxx/CxxItaniumEHCorpusManifestTests.cpp
   corpus/cxx/CxxItaniumEHCorpusManifest.cpp
@@ -454,6 +468,29 @@ if(NEVERD_HAVE_CXX_ITANIUM_EH_CORPUS)
     NeverDSupport
   )
   add_dependencies(NeverDCxxItaniumEHCorpusTests neverd)
+endif()
+
+if(NEVERD_HAVE_ADA_D_EH_CORPUS)
+  add_neverd_unittest(NeverDAdaDEHCorpusTests
+    corpus/ada-d-eh/AdaDEHCorpusTests.cpp
+    corpus/ada-d-eh/AdaDEHCorpusManifest.cpp
+    TIMEOUT 600
+  )
+
+  target_compile_definitions(NeverDAdaDEHCorpusTests PRIVATE
+    NEVERD_BINARY_CORPUS_ROOT="${NEVERD_BINARY_CORPUS_ROOT}"
+  )
+
+  target_include_directories(NeverDAdaDEHCorpusTests PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/include
+    ${LLVM_INCLUDE_DIRS}
+  )
+
+  target_link_libraries(NeverDAdaDEHCorpusTests PRIVATE
+    NeverDLoader
+    NeverDSupport
+  )
 endif()
 
 if(NEVERD_HAVE_OBJC_EH_CORPUS)

--- a/unittests/lift/corpus/ada-d-eh/AdaDEHCorpusManifest.cpp
+++ b/unittests/lift/corpus/ada-d-eh/AdaDEHCorpusManifest.cpp
@@ -1,0 +1,425 @@
+//===- AdaDEHCorpusManifest.cpp - Corpus manifest reader ----------------===//
+//
+// NeverD Decompiler
+//
+//===----------------------------------------------------------------------===//
+
+#include "AdaDEHCorpusManifest.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/JSON.h"
+#include "llvm/Support/MemoryBuffer.h"
+
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+
+using namespace llvm;
+
+namespace neverd::test {
+namespace {
+
+struct TargetIdentity {
+  Arch TheArch;
+  StringRef Architecture;
+  bool Native;
+};
+
+struct ToolchainIdentity {
+  StringRef Language;
+  StringRef Personality;
+  AdaDDescriptorABI DescriptorABI;
+  uint64_t MinCleanupPads;
+};
+
+Error manifestError(const Twine &Message) {
+  return make_error<StringError>(Message, inconvertibleErrorCode());
+}
+
+Expected<std::string> requireString(const json::Object &Object, StringRef Key,
+                                    StringRef Context) {
+  std::optional<StringRef> Value = Object.getString(Key);
+  if (!Value || Value->empty())
+    return manifestError(Context + ": missing string '" + Key + "'");
+  return Value->str();
+}
+
+Expected<bool> requireBoolean(const json::Object &Object, StringRef Key,
+                              StringRef Context) {
+  std::optional<bool> Value = Object.getBoolean(Key);
+  if (!Value)
+    return manifestError(Context + ": missing boolean '" + Key + "'");
+  return *Value;
+}
+
+Expected<uint64_t> requireNonNegativeInteger(const json::Object &Object,
+                                             StringRef Key, StringRef Context) {
+  std::optional<int64_t> Value = Object.getInteger(Key);
+  if (!Value || *Value < 0)
+    return manifestError(Context + ": missing non-negative integer '" + Key +
+                         "'");
+  return static_cast<uint64_t>(*Value);
+}
+
+Expected<std::vector<std::string>>
+requireStringArray(const json::Object &Object, StringRef Key, StringRef Context,
+                   bool AllowEmpty) {
+  const json::Array *Values = Object.getArray(Key);
+  if (!Values || (!AllowEmpty && Values->empty()))
+    return manifestError(Context + ": invalid string array '" + Key + "'");
+  std::vector<std::string> Result;
+  Result.reserve(Values->size());
+  for (const json::Value &Value : *Values) {
+    std::optional<StringRef> String = Value.getAsString();
+    if (!String || String->empty())
+      return manifestError(Context + ": non-string value in '" + Key + "'");
+    Result.push_back(String->str());
+  }
+  return Result;
+}
+
+std::optional<TargetIdentity> getTargetIdentity(StringRef Target) {
+  if (Target == "x86_64-linux-gnu")
+    return TargetIdentity{Arch::X64, "x86_64", true};
+  if (Target == "aarch64-linux-gnu")
+    return TargetIdentity{Arch::AArch64, "aarch64", false};
+  return std::nullopt;
+}
+
+std::optional<ToolchainIdentity> getToolchainIdentity(StringRef Toolchain) {
+  if (Toolchain == "gnat")
+    return ToolchainIdentity{"ada", "__gnat_personality_v0",
+                             AdaDDescriptorABI::GnatExceptionId, 0};
+  if (Toolchain == "gdc")
+    return ToolchainIdentity{"d", "__gdc_personality_v0",
+                             AdaDDescriptorABI::DClassInfo, 1};
+  if (Toolchain == "dmd")
+    return ToolchainIdentity{"d", "__dmd_personality_v0",
+                             AdaDDescriptorABI::DClassInfo, 1};
+  if (Toolchain == "ldc")
+    return ToolchainIdentity{"d", "_d_eh_personality",
+                             AdaDDescriptorABI::DClassInfo, 1};
+  return std::nullopt;
+}
+
+bool isNormalizedCorpusPath(StringRef Path) {
+  if (Path.empty() || Path.starts_with('/') || Path.contains('\\'))
+    return false;
+  SmallVector<StringRef, 16> Parts;
+  Path.split(Parts, '/', -1, true);
+  if (Parts.empty())
+    return false;
+  return llvm::none_of(Parts, [](StringRef Part) {
+    return Part.empty() || Part == "." || Part == "..";
+  });
+}
+
+bool isLowerSHA256(StringRef Hash) {
+  return Hash.size() == 64 && llvm::all_of(Hash, [](char C) {
+           return (C >= '0' && C <= '9') || (C >= 'a' && C <= 'f');
+         });
+}
+
+std::string cellKey(StringRef Toolchain, StringRef Target) {
+  return (Toolchain + "-" + Target).str();
+}
+
+Error verifyContract(const AdaDEHArtifactExpectation &Expectation,
+                     StringRef Context) {
+  std::optional<ToolchainIdentity> Toolchain =
+      getToolchainIdentity(Expectation.Toolchain);
+  std::optional<TargetIdentity> Target = getTargetIdentity(Expectation.Target);
+  if (!Toolchain || !Target)
+    return manifestError(Context + ": unsupported cell");
+  if (Expectation.SourceLanguage != Toolchain->Language)
+    return manifestError(Context + ": language disagrees with the toolchain");
+  if (Expectation.Architecture != Target->Architecture ||
+      Expectation.ExpectedArch != Target->TheArch)
+    return manifestError(Context + ": architecture disagrees with the target");
+  if (Expectation.ObjectFormat != "elf" ||
+      Expectation.ExpectedFormat != BinaryFormat::ELF)
+    return manifestError(Context + ": Ada/D corpus artifacts are ELF only");
+  const StringRef ExpectedExecution =
+      Target->Native ? StringRef("passed") : StringRef("not-run-cross-target");
+  if (Expectation.Execution != ExpectedExecution)
+    return manifestError(Context + ": execution status disagrees with target");
+  if (Expectation.Personalities !=
+      std::vector<std::string>{Toolchain->Personality.str()})
+    return manifestError(Context + ": personality disagrees with the toolchain");
+  if (Expectation.DescriptorABI != Toolchain->DescriptorABI)
+    return manifestError(Context +
+                         ": descriptor ABI disagrees with the toolchain");
+  if (Expectation.MinCleanupPads != Toolchain->MinCleanupPads)
+    return manifestError(Context +
+                         ": cleanup floor disagrees with the language");
+  if (Expectation.MinCallSites == 0 || Expectation.MinLandingPads == 0 ||
+      Expectation.MinCatchClauses == 0 || Expectation.MinTypeTableEntries == 0)
+    return manifestError(Context + ": lsda-graph contract has a zero floor");
+
+  const StringRef Probe =
+      Expectation.SourceLanguage == "ada" ? "ada_eh_probe" : "d_eh_probe";
+  const std::string ExpectedPath =
+      ("corpus/ada-d-eh/" + Expectation.SourceLanguage + "/" +
+       Expectation.Toolchain + "/" + Expectation.Target + "/" +
+       Expectation.Optimization + "/" + Probe + "-" + Expectation.Toolchain +
+       "-" + Expectation.Target + "-" + Expectation.Optimization)
+          .str();
+  if (Expectation.Path != ExpectedPath)
+    return manifestError(Context + ": artifact path disagrees with build axes");
+  return Error::success();
+}
+
+Expected<AdaDEHArtifactExpectation> parseArtifact(const json::Object &Object,
+                                                  size_t Index) {
+  AdaDEHArtifactExpectation Result;
+  const std::string Context = ("artifacts[" + Twine(Index) + "]").str();
+
+  auto Path = requireString(Object, "path", Context);
+  if (!Path)
+    return Path.takeError();
+  Result.Path = std::move(*Path);
+  if (!isNormalizedCorpusPath(Result.Path))
+    return manifestError(Context + ": artifact path is not repository-relative");
+
+  auto Hash = requireString(Object, "sha256", Context);
+  if (!Hash)
+    return Hash.takeError();
+  Result.SHA256 = std::move(*Hash);
+  if (!isLowerSHA256(Result.SHA256))
+    return manifestError(Context + ": sha256 is not a lowercase hex digest");
+  auto Size = requireNonNegativeInteger(Object, "size", Context);
+  if (!Size)
+    return Size.takeError();
+  Result.Size = *Size;
+  if (Result.Size == 0)
+    return manifestError(Context + ": artifact size is zero");
+
+  auto Toolchain = requireString(Object, "toolchain", Context);
+  if (!Toolchain)
+    return Toolchain.takeError();
+  Result.Toolchain = std::move(*Toolchain);
+  std::optional<ToolchainIdentity> Shape =
+      getToolchainIdentity(Result.Toolchain);
+  if (!Shape)
+    return manifestError(Context + ": unsupported toolchain");
+
+  auto Target = requireString(Object, "target", Context);
+  if (!Target)
+    return Target.takeError();
+  Result.Target = std::move(*Target);
+  std::optional<TargetIdentity> Identity = getTargetIdentity(Result.Target);
+  if (!Identity)
+    return manifestError(Context + ": unsupported target");
+  Result.ExpectedArch = Identity->TheArch;
+
+  auto Architecture = requireString(Object, "architecture", Context);
+  if (!Architecture)
+    return Architecture.takeError();
+  Result.Architecture = std::move(*Architecture);
+  auto ObjectFormat = requireString(Object, "object_format", Context);
+  if (!ObjectFormat)
+    return ObjectFormat.takeError();
+  Result.ObjectFormat = std::move(*ObjectFormat);
+  Result.ExpectedFormat = BinaryFormat::ELF;
+
+  auto Language = requireString(Object, "source_language", Context);
+  if (!Language)
+    return Language.takeError();
+  Result.SourceLanguage = std::move(*Language);
+  auto Optimization = requireString(Object, "optimization", Context);
+  if (!Optimization)
+    return Optimization.takeError();
+  Result.Optimization = std::move(*Optimization);
+  if (Result.Optimization != "o0" && Result.Optimization != "o2")
+    return manifestError(Context + ": unsupported optimization");
+  auto Execution = requireString(Object, "execution", Context);
+  if (!Execution)
+    return Execution.takeError();
+  Result.Execution = std::move(*Execution);
+
+  if (Object.getString("exception_model") != "itanium-dwarf")
+    return manifestError(Context + ": exception model is not itanium-dwarf");
+
+  const json::Object *Evidence = Object.getObject("evidence");
+  if (!Evidence)
+    return manifestError(Context + ": missing object 'evidence'");
+  auto Sections = requireStringArray(*Evidence, "required_sections",
+                                     Context + ".evidence", false);
+  if (!Sections)
+    return Sections.takeError();
+  Result.RequiredSections = std::move(*Sections);
+  auto Symbols = requireStringArray(*Evidence, "required_symbols",
+                                    Context + ".evidence", false);
+  if (!Symbols)
+    return Symbols.takeError();
+  Result.RequiredSymbols = std::move(*Symbols);
+  auto Strings = requireStringArray(*Evidence, "required_strings",
+                                    Context + ".evidence", false);
+  if (!Strings)
+    return Strings.takeError();
+  Result.RequiredStrings = std::move(*Strings);
+  auto Unwind =
+      requireBoolean(*Evidence, "require_unwind_tables", Context + ".evidence");
+  if (!Unwind)
+    return Unwind.takeError();
+  if (!*Unwind)
+    return manifestError(Context + ": Ada/D cells require unwind tables");
+  auto EhFrame =
+      requireBoolean(*Evidence, "eh_frame_present", Context + ".evidence");
+  if (!EhFrame)
+    return EhFrame.takeError();
+  if (!*EhFrame)
+    return manifestError(Context + ": Ada/D cells require .eh_frame");
+
+  const json::Object *NeverD = Object.getObject("neverd");
+  if (!NeverD)
+    return manifestError(Context + ": missing object 'neverd'");
+  if (NeverD->getString("validation_level") != "lsda-graph")
+    return manifestError(Context + ": validation level is not lsda-graph");
+  if (NeverD->getString("type_table_interpretation") != "opaque-descriptor")
+    return manifestError(Context +
+                         ": type-table interpretation is not opaque-descriptor");
+  if (NeverD->getString("native_reconstruction") != "address-clauses")
+    return manifestError(Context +
+                         ": native reconstruction is not address-clauses");
+  auto Proven = requireBoolean(*NeverD, "corpus_proven", Context + ".neverd");
+  if (!Proven)
+    return Proven.takeError();
+  if (!*Proven)
+    return manifestError(Context + ": corpus-proven must stay a separate true claim");
+
+  auto Descriptor =
+      requireString(*NeverD, "descriptor_abi", Context + ".neverd");
+  if (!Descriptor)
+    return Descriptor.takeError();
+  if (*Descriptor == "gnat-exception-id")
+    Result.DescriptorABI = AdaDDescriptorABI::GnatExceptionId;
+  else if (*Descriptor == "d-classinfo")
+    Result.DescriptorABI = AdaDDescriptorABI::DClassInfo;
+  else
+    return manifestError(Context + ": unsupported descriptor ABI");
+
+  auto Personalities = requireStringArray(*NeverD, "personalities_any",
+                                          Context + ".neverd", false);
+  if (!Personalities)
+    return Personalities.takeError();
+  Result.Personalities = std::move(*Personalities);
+
+  struct Minimum {
+    StringRef Key;
+    uint64_t *Field;
+  };
+  const Minimum Minimums[] = {
+      {"min_call_sites", &Result.MinCallSites},
+      {"min_landing_pads", &Result.MinLandingPads},
+      {"min_catch_clauses", &Result.MinCatchClauses},
+      {"min_cleanup_pads", &Result.MinCleanupPads},
+      {"min_type_table_entries", &Result.MinTypeTableEntries},
+  };
+  for (const Minimum &Entry : Minimums) {
+    auto Value =
+        requireNonNegativeInteger(*NeverD, Entry.Key, Context + ".neverd");
+    if (!Value)
+      return Value.takeError();
+    *Entry.Field = *Value;
+  }
+
+  if (Error Failure = verifyContract(Result, Context))
+    return std::move(Failure);
+  return Result;
+}
+
+std::set<std::string> expectedCells() {
+  return {
+      "dmd-x86_64-linux-gnu",
+      "gdc-aarch64-linux-gnu",
+      "gdc-x86_64-linux-gnu",
+      "gnat-aarch64-linux-gnu",
+      "gnat-x86_64-linux-gnu",
+      "ldc-x86_64-linux-gnu",
+  };
+}
+
+Error verifyCompleteMatrix(ArrayRef<AdaDEHArtifactExpectation> Expectations) {
+  std::map<std::string, std::set<std::string>> VariantsByCell;
+  for (const AdaDEHArtifactExpectation &Expectation : Expectations) {
+    const std::string Key = cellKey(Expectation.Toolchain, Expectation.Target);
+    if (!VariantsByCell[Key].insert(Expectation.Optimization).second)
+      return manifestError("duplicate variant in corpus matrix cell " + Key);
+  }
+
+  std::map<std::string, std::set<std::string>> Expected;
+  for (const std::string &Cell : expectedCells())
+    Expected.emplace(Cell, std::set<std::string>{"o0", "o2"});
+  if (VariantsByCell != Expected)
+    return manifestError(
+        "corpus manifest does not contain the complete build matrix");
+  if (Expectations.size() != 12u)
+    return manifestError(
+        "corpus manifest artifact count disagrees with its build matrix");
+  return Error::success();
+}
+
+} // namespace
+
+const char *getAdaDDescriptorABIName(AdaDDescriptorABI ABI) {
+  switch (ABI) {
+  case AdaDDescriptorABI::GnatExceptionId:
+    return "gnat-exception-id";
+  case AdaDDescriptorABI::DClassInfo:
+    return "d-classinfo";
+  }
+  return "unknown";
+}
+
+Expected<std::vector<AdaDEHArtifactExpectation>>
+parseAdaDEHCorpusManifest(StringRef Contents, bool RequireCompleteMatrix) {
+  auto Parsed = json::parse(Contents);
+  if (!Parsed)
+    return Parsed.takeError();
+  const json::Object *Root = Parsed->getAsObject();
+  if (!Root)
+    return manifestError("corpus manifest root is not an object");
+  if (Root->getInteger("schema_version") != 1 ||
+      Root->getString("corpus") != "ada-d-eh")
+    return manifestError("unsupported corpus manifest identity");
+  const json::Array *Artifacts = Root->getArray("artifacts");
+  if (!Artifacts || Artifacts->empty())
+    return manifestError("corpus manifest contains no artifacts");
+
+  std::vector<AdaDEHArtifactExpectation> Result;
+  Result.reserve(Artifacts->size());
+  std::set<std::string> Paths;
+  for (size_t I = 0; I < Artifacts->size(); ++I) {
+    const json::Object *Object = (*Artifacts)[I].getAsObject();
+    if (!Object)
+      return manifestError("artifact entry is not an object");
+    auto Expectation = parseArtifact(*Object, I);
+    if (!Expectation)
+      return Expectation.takeError();
+    if (!Paths.insert(Expectation->Path).second)
+      return manifestError("duplicate artifact path '" + Expectation->Path +
+                           "'");
+    Result.push_back(std::move(*Expectation));
+  }
+  if (RequireCompleteMatrix)
+    if (Error Failure = verifyCompleteMatrix(Result))
+      return std::move(Failure);
+  return Result;
+}
+
+Expected<std::vector<AdaDEHArtifactExpectation>>
+loadAdaDEHCorpusManifest(StringRef Path, bool RequireCompleteMatrix) {
+  auto BufferOrErr = MemoryBuffer::getFile(Path);
+  if (!BufferOrErr)
+    return manifestError("cannot read corpus manifest '" + Path +
+                         "': " + BufferOrErr.getError().message());
+  return parseAdaDEHCorpusManifest((*BufferOrErr)->getBuffer(),
+                                   RequireCompleteMatrix);
+}
+
+} // namespace neverd::test

--- a/unittests/lift/corpus/ada-d-eh/AdaDEHCorpusManifest.h
+++ b/unittests/lift/corpus/ada-d-eh/AdaDEHCorpusManifest.h
@@ -1,0 +1,65 @@
+//===- AdaDEHCorpusManifest.h - Corpus manifest reader --------*- C++ -*-===//
+//
+// NeverD Decompiler
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef NEVERD_UNITTESTS_LIFT_ADADEHCORPUSMANIFEST_H
+#define NEVERD_UNITTESTS_LIFT_ADADEHCORPUSMANIFEST_H
+
+#include "neverd/Common.h"
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace neverd::test {
+
+/// What a type-table slot names for this language runtime.
+enum class AdaDDescriptorABI : uint8_t {
+  GnatExceptionId,
+  DClassInfo,
+};
+
+struct AdaDEHArtifactExpectation {
+  std::string Path;
+  std::string SHA256;
+  uint64_t Size = 0;
+
+  std::string Toolchain;
+  std::string Target;
+  std::string Architecture;
+  Arch ExpectedArch = Arch::Unknown;
+  std::string ObjectFormat;
+  BinaryFormat ExpectedFormat = BinaryFormat::Unknown;
+  std::string SourceLanguage;
+  std::string Optimization;
+  std::string Execution;
+
+  std::vector<std::string> RequiredSections;
+  std::vector<std::string> RequiredSymbols;
+  std::vector<std::string> RequiredStrings;
+
+  std::vector<std::string> Personalities;
+  AdaDDescriptorABI DescriptorABI = AdaDDescriptorABI::GnatExceptionId;
+  uint64_t MinCallSites = 0;
+  uint64_t MinLandingPads = 0;
+  uint64_t MinCatchClauses = 0;
+  uint64_t MinCleanupPads = 0;
+  uint64_t MinTypeTableEntries = 0;
+};
+
+const char *getAdaDDescriptorABIName(AdaDDescriptorABI ABI);
+
+llvm::Expected<std::vector<AdaDEHArtifactExpectation>>
+parseAdaDEHCorpusManifest(llvm::StringRef Contents, bool RequireCompleteMatrix);
+
+llvm::Expected<std::vector<AdaDEHArtifactExpectation>>
+loadAdaDEHCorpusManifest(llvm::StringRef Path, bool RequireCompleteMatrix);
+
+} // namespace neverd::test
+
+#endif

--- a/unittests/lift/corpus/ada-d-eh/AdaDEHCorpusManifestTests.cpp
+++ b/unittests/lift/corpus/ada-d-eh/AdaDEHCorpusManifestTests.cpp
@@ -1,0 +1,136 @@
+//===- AdaDEHCorpusManifestTests.cpp - Corpus contract tests ------------===//
+//
+// NeverD Decompiler
+//
+//===----------------------------------------------------------------------===//
+
+#include "AdaDEHCorpusManifest.h"
+#include "gtest/gtest.h"
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/Support/Error.h"
+
+#include <string>
+
+using namespace llvm;
+using namespace neverd;
+using namespace neverd::test;
+
+namespace {
+
+struct Cell {
+  StringRef Path =
+      "corpus/ada-d-eh/ada/gnat/x86_64-linux-gnu/o0/"
+      "ada_eh_probe-gnat-x86_64-linux-gnu-o0";
+  StringRef Toolchain = "gnat";
+  StringRef Target = "x86_64-linux-gnu";
+  StringRef Architecture = "x86_64";
+  StringRef SourceLanguage = "ada";
+  StringRef Optimization = "o0";
+  StringRef Execution = "passed";
+  StringRef Personality = "__gnat_personality_v0";
+  StringRef DescriptorABI = "gnat-exception-id";
+  StringRef MinCleanupPads = "0";
+};
+
+Cell dmdCell() {
+  Cell C;
+  C.Path = "corpus/ada-d-eh/d/dmd/x86_64-linux-gnu/o0/"
+           "d_eh_probe-dmd-x86_64-linux-gnu-o0";
+  C.Toolchain = "dmd";
+  C.SourceLanguage = "d";
+  C.Personality = "__dmd_personality_v0";
+  C.DescriptorABI = "d-classinfo";
+  C.MinCleanupPads = "1";
+  return C;
+}
+
+std::string artifactJSON(const Cell &C) {
+  return (Twine("{\"path\":\"") + C.Path + "\",\"sha256\":\"" +
+          std::string(64, 'a') + "\",\"size\":1024,\"toolchain\":\"" +
+          C.Toolchain + "\",\"toolchain_version\":\"13.3.0\",\"target\":\"" +
+          C.Target + "\",\"architecture\":\"" + C.Architecture +
+          "\",\"object_format\":\"elf\",\"source_language\":\"" +
+          C.SourceLanguage + "\",\"optimization\":\"" + C.Optimization +
+          "\",\"execution\":\"" + C.Execution +
+          "\",\"exception_model\":\"itanium-dwarf\","
+          "\"evidence\":{\"required_sections\":[\".eh_frame\","
+          "\".gcc_except_table\"],\"required_symbols\":[\"" +
+          C.Personality +
+          "\"],\"required_strings\":[\"ada-d-eh probe passed\"],"
+          "\"require_unwind_tables\":true,\"eh_frame_present\":true,"
+          "\"checkout_path_absent\":true},"
+          "\"neverd\":{\"validation_level\":\"lsda-graph\","
+          "\"personalities_any\":[\"" +
+          C.Personality +
+          "\"],\"type_table_interpretation\":\"opaque-descriptor\","
+          "\"descriptor_abi\":\"" +
+          C.DescriptorABI +
+          "\",\"native_reconstruction\":\"address-clauses\","
+          "\"corpus_proven\":true,\"min_call_sites\":1,\"min_landing_pads\":1,"
+          "\"min_catch_clauses\":3,\"min_cleanup_pads\":" +
+          C.MinCleanupPads + ",\"min_type_table_entries\":3}}")
+      .str();
+}
+
+std::string manifestFor(const Cell &C) {
+  return (Twine("{\"schema_version\":1,\"corpus\":\"ada-d-eh\",\"artifacts\":[") +
+          artifactJSON(C) + "]}")
+      .str();
+}
+
+Expected<std::vector<AdaDEHArtifactExpectation>> parse(const Cell &C) {
+  return parseAdaDEHCorpusManifest(manifestFor(C), false);
+}
+
+void expectRejected(const Cell &C, const char *Because) {
+  auto Result = parse(C);
+  if (Result) {
+    ADD_FAILURE() << "accepted a manifest that " << Because;
+    return;
+  }
+  consumeError(Result.takeError());
+}
+
+} // namespace
+
+TEST(AdaDEHCorpusManifest, ReadsAdaAndDPersonalities) {
+  auto Ada = parse(Cell());
+  ASSERT_TRUE(static_cast<bool>(Ada)) << toString(Ada.takeError());
+  ASSERT_EQ(Ada->size(), 1u);
+  EXPECT_EQ(Ada->front().ExpectedFormat, BinaryFormat::ELF);
+  EXPECT_EQ(Ada->front().ExpectedArch, Arch::X64);
+  EXPECT_EQ(Ada->front().Personalities.front(), "__gnat_personality_v0");
+  EXPECT_EQ(Ada->front().DescriptorABI, AdaDDescriptorABI::GnatExceptionId);
+
+  auto D = parse(dmdCell());
+  ASSERT_TRUE(static_cast<bool>(D)) << toString(D.takeError());
+  ASSERT_EQ(D->size(), 1u);
+  EXPECT_EQ(D->front().Personalities.front(), "__dmd_personality_v0");
+  EXPECT_EQ(D->front().DescriptorABI, AdaDDescriptorABI::DClassInfo);
+}
+
+TEST(AdaDEHCorpusManifest, RejectsACXXRTTIInterpretation) {
+  std::string Text = manifestFor(Cell());
+  const std::string From = "\"type_table_interpretation\":\"opaque-descriptor\"";
+  const std::string To = "\"type_table_interpretation\":\"cxx-rtti\"";
+  const auto Pos = Text.find(From);
+  ASSERT_NE(Pos, std::string::npos);
+  Text.replace(Pos, From.size(), To);
+  auto Result = parseAdaDEHCorpusManifest(Text, false);
+  ASSERT_FALSE(static_cast<bool>(Result));
+  consumeError(Result.takeError());
+}
+
+TEST(AdaDEHCorpusManifest, RejectsAPersonalityThatDoesNotMatchTheToolchain) {
+  Cell C;
+  C.Personality = "__gxx_personality_v0";
+  expectRejected(C, "installed a C++ personality on a GNAT cell");
+}
+
+TEST(AdaDEHCorpusManifest, RejectsAnIncompleteMatrix) {
+  auto Result = parseAdaDEHCorpusManifest(manifestFor(Cell()), true);
+  ASSERT_FALSE(static_cast<bool>(Result));
+  consumeError(Result.takeError());
+}

--- a/unittests/lift/corpus/ada-d-eh/AdaDEHCorpusTests.cpp
+++ b/unittests/lift/corpus/ada-d-eh/AdaDEHCorpusTests.cpp
@@ -1,0 +1,185 @@
+//===- AdaDEHCorpusTests.cpp - Ada/D Itanium corpus consumer tests ------===//
+//
+// NeverD Decompiler
+//
+//===----------------------------------------------------------------------===//
+
+#include "gtest/gtest.h"
+
+#include "AdaDEHCorpusTestsDetail.h"
+
+namespace {
+
+using namespace llvm;
+using namespace neverd;
+using namespace neverd::test;
+using namespace neverd::ada_d_corpus_test;
+
+TEST(AdaDEHCorpus, DeclaresCompleteBuildMatrix) {
+  auto ExpectationsOrErr = loadExpectations();
+  ASSERT_TRUE(static_cast<bool>(ExpectationsOrErr))
+      << toString(ExpectationsOrErr.takeError());
+  EXPECT_EQ(ExpectationsOrErr->size(), 12u);
+
+  std::set<std::string> Cells;
+  std::set<std::string> Personalities;
+  std::set<std::string> Descriptors;
+  for (const AdaDEHArtifactExpectation &Expectation : *ExpectationsOrErr) {
+    Cells.insert(Expectation.Toolchain + "-" + Expectation.Target);
+    Personalities.insert(Expectation.Personalities.front());
+    Descriptors.insert(getAdaDDescriptorABIName(Expectation.DescriptorABI));
+    EXPECT_EQ(Expectation.ExpectedFormat, BinaryFormat::ELF);
+  }
+  EXPECT_EQ(Cells.size(), 6u);
+  EXPECT_EQ(Personalities, (std::set<std::string>{"__dmd_personality_v0",
+                                                  "__gdc_personality_v0",
+                                                  "__gnat_personality_v0",
+                                                  "_d_eh_personality"}));
+  EXPECT_EQ(Descriptors, (std::set<std::string>{"d-classinfo",
+                                                "gnat-exception-id"}));
+}
+
+TEST(AdaDEHCorpus, MatchesDeclaredBytesAndContainer) {
+  auto ExpectationsOrErr = loadExpectations();
+  ASSERT_TRUE(static_cast<bool>(ExpectationsOrErr))
+      << toString(ExpectationsOrErr.takeError());
+  const std::filesystem::path CorpusRoot(NEVERD_BINARY_CORPUS_ROOT);
+
+  for (const AdaDEHArtifactExpectation &Expectation : *ExpectationsOrErr) {
+    SCOPED_TRACE(Expectation.Path);
+    const std::filesystem::path ArtifactPath = CorpusRoot / Expectation.Path;
+    auto BufferOrErr = MemoryBuffer::getFile(ArtifactPath.string());
+    if (!BufferOrErr) {
+      ADD_FAILURE() << "cannot read artifact: "
+                    << BufferOrErr.getError().message();
+      continue;
+    }
+    StringRef Bytes = (*BufferOrErr)->getBuffer();
+    if (Bytes.size() != Expectation.Size) {
+      ADD_FAILURE() << "artifact size does not match the manifest";
+      continue;
+    }
+    std::array<uint8_t, 32> Digest = SHA256::hash(arrayRefFromStringRef(Bytes));
+    if (toHex(ArrayRef<uint8_t>(Digest), true) != Expectation.SHA256) {
+      ADD_FAILURE() << "artifact SHA-256 does not match the manifest";
+      continue;
+    }
+
+    std::optional<BinaryImage> Image = loadArtifact(ArtifactPath);
+    if (!Image)
+      continue;
+    EXPECT_EQ(Image->Format, Expectation.ExpectedFormat);
+    EXPECT_EQ(Image->Arch, Expectation.ExpectedArch);
+    for (const std::string &Name : Expectation.RequiredSections)
+      EXPECT_TRUE(Image->hasSection(Name))
+          << "the manifest requires section " << Name;
+
+    const ExceptionInfo &Info = Image->ExceptionMetadata;
+    EXPECT_NE(Info.ParseStatus, ExceptionParseStatus::Malformed)
+        << diagnosticsFor(Info);
+    for (const ExceptionFunction &Function : Info.Functions)
+      EXPECT_NE(Function.ParseStatus, ExceptionParseStatus::Malformed)
+          << diagnosticsFor(Info);
+  }
+}
+
+TEST(AdaDEHCorpus, RecoversTheCallSiteGraphOnEveryCell) {
+  auto ExpectationsOrErr = loadExpectations();
+  ASSERT_TRUE(static_cast<bool>(ExpectationsOrErr))
+      << toString(ExpectationsOrErr.takeError());
+  const std::filesystem::path CorpusRoot(NEVERD_BINARY_CORPUS_ROOT);
+
+  unsigned Images = 0;
+  for (const AdaDEHArtifactExpectation &Expectation : *ExpectationsOrErr) {
+    std::optional<BinaryImage> Image =
+        loadArtifact(CorpusRoot / Expectation.Path);
+    if (!Image)
+      continue;
+    ++Images;
+    SCOPED_TRACE(Expectation.Path);
+
+    const ExceptionInfo &Info = Image->ExceptionMetadata;
+    const std::string Diagnostics = diagnosticsFor(Info);
+
+    std::set<std::string> Personalities;
+    for (const ExceptionFunction &Function : Info.Functions) {
+      if (!Function.Itanium)
+        continue;
+      Personalities.insert(getExceptionPersonalityName(Function.Personality));
+      for (const ItaniumCallSite &Site : Function.Itanium->CallSites) {
+        EXPECT_TRUE(Site.GuardedRange.isValid());
+        EXPECT_TRUE(Function.CodeRange.contains(Site.GuardedRange))
+            << "call site at 0x" << utohexstr(Site.GuardedRange.Begin)
+            << " lies outside its frame";
+        if (Site.LandingPadVA == 0)
+          continue;
+        const Segment *Seg = Image->getSegmentFor(Site.LandingPadVA);
+        EXPECT_TRUE(Seg != nullptr && Seg->isExecutable())
+            << "landing pad 0x" << utohexstr(Site.LandingPadVA)
+            << " does not name code";
+      }
+      for (const ItaniumAction &Action : Function.Itanium->Actions)
+        if (Action.isCatch())
+          EXPECT_LE(static_cast<uint64_t>(Action.TypeFilter),
+                    Function.Itanium->TypeTable.size())
+              << "catch filter names a slot the type table does not have";
+    }
+    const bool PersonalityMatched =
+        llvm::any_of(Expectation.Personalities, [&](const std::string &Name) {
+          return Personalities.contains(Name);
+        });
+    EXPECT_TRUE(PersonalityMatched)
+        << "parsed personalities did not include any the manifest allows; "
+        << Diagnostics;
+
+    const GraphCensus Census = censusOf(Info);
+    EXPECT_GT(Census.Records, 0u) << Diagnostics;
+    EXPECT_GE(Census.CallSites, Expectation.MinCallSites) << Diagnostics;
+    EXPECT_GE(Census.LandingPads, Expectation.MinLandingPads) << Diagnostics;
+    EXPECT_GE(Census.CatchClauses, Expectation.MinCatchClauses) << Diagnostics;
+    // D `scope (exit)` is a producer/manifest claim. DMD encodes it as a
+    // catch of Throwable rather than a cleanup action, so the LSDA census
+    // cannot prove that floor across the matrix.
+    EXPECT_GE(Census.TypeTableEntries, Expectation.MinTypeTableEntries)
+        << Diagnostics;
+  }
+  EXPECT_EQ(Images, 12u);
+}
+
+TEST(AdaDEHCorpus, KeepsAdaAndDTypeDescriptorsOpaque) {
+  auto ExpectationsOrErr = loadExpectations();
+  ASSERT_TRUE(static_cast<bool>(ExpectationsOrErr))
+      << toString(ExpectationsOrErr.takeError());
+  const std::filesystem::path CorpusRoot(NEVERD_BINARY_CORPUS_ROOT);
+
+  unsigned TypedFrames = 0;
+  for (const AdaDEHArtifactExpectation &Expectation : *ExpectationsOrErr) {
+    std::optional<BinaryImage> Image =
+        loadArtifact(CorpusRoot / Expectation.Path);
+    if (!Image)
+      continue;
+    SCOPED_TRACE(Expectation.Path);
+
+    for (const ExceptionFunction &Function : Image->ExceptionMetadata.Functions) {
+      if (!Function.Itanium)
+        continue;
+      const ItaniumEHInfo &LSDA = *Function.Itanium;
+      EXPECT_EQ(LSDA.TypeTableEntryKind,
+                ItaniumTypeTableEntryKind::OpaqueDescriptor);
+      for (const ItaniumTypeEntry &Entry : LSDA.TypeTable) {
+        if (Entry.IsCatchAll)
+          continue;
+        ++TypedFrames;
+        llvm::StringRef Name(Entry.TypeName);
+        EXPECT_FALSE(Name.starts_with("_ZTI") || Name.starts_with("__ZTI"))
+            << "opaque descriptor was followed as std::type_info: "
+            << Entry.TypeName;
+        EXPECT_TRUE(Entry.TypeInfoVA != 0 || Entry.TypeInfoSlotVA != 0)
+            << "typed slot lost its descriptor address";
+      }
+    }
+  }
+  EXPECT_GT(TypedFrames, 0u);
+}
+
+} // namespace

--- a/unittests/lift/corpus/ada-d-eh/AdaDEHCorpusTestsDetail.h
+++ b/unittests/lift/corpus/ada-d-eh/AdaDEHCorpusTestsDetail.h
@@ -1,0 +1,106 @@
+//===- AdaDEHCorpusTestsDetail.h - Ada/D corpus test harness --*- C++ -*-===//
+//
+// NeverD Decompiler
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef NEVERD_UNITTESTS_LIFT_CORPUS_ADA_D_EH_ADADEHCORPUSTESTSDETAIL_H
+#define NEVERD_UNITTESTS_LIFT_CORPUS_ADA_D_EH_ADADEHCORPUSTESTSDETAIL_H
+
+#include "AdaDEHCorpusManifest.h"
+#include "gtest/gtest.h"
+
+#include "neverd/loader/BinaryImage.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/SHA256.h"
+
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace neverd::ada_d_corpus_test {
+
+inline llvm::Expected<std::vector<test::AdaDEHArtifactExpectation>>
+loadExpectations() {
+  const std::filesystem::path ManifestPath =
+      std::filesystem::path(NEVERD_BINARY_CORPUS_ROOT) / "manifests" /
+      "ada-d-eh.json";
+  return test::loadAdaDEHCorpusManifest(ManifestPath.string(), true);
+}
+
+inline std::string diagnosticsFor(const ExceptionInfo &Info) {
+  std::string Result;
+  for (const std::string &Diagnostic : Info.Diagnostics) {
+    if (!Result.empty())
+      Result += "; ";
+    Result += Diagnostic;
+  }
+  for (const ExceptionFunction &Function : Info.Functions)
+    for (const std::string &Diagnostic : Function.Diagnostics) {
+      if (!Result.empty())
+        Result += "; ";
+      Result += Diagnostic;
+    }
+  return Result;
+}
+
+inline std::optional<BinaryImage> loadArtifact(const std::filesystem::path &Path) {
+  std::unique_ptr<Loader> ImageLoader = Loader::create(Path);
+  if (!ImageLoader) {
+    ADD_FAILURE() << "NeverD did not recognize " << Path.string();
+    return std::nullopt;
+  }
+  auto ImageOrErr = ImageLoader->load(Path);
+  if (!ImageOrErr) {
+    ADD_FAILURE() << "cannot load " << Path.string() << ": "
+                  << llvm::toString(ImageOrErr.takeError());
+    return std::nullopt;
+  }
+  return std::move(*ImageOrErr);
+}
+
+struct GraphCensus {
+  uint64_t Records = 0;
+  uint64_t CallSites = 0;
+  uint64_t LandingPads = 0;
+  uint64_t CatchClauses = 0;
+  uint64_t TypeTableEntries = 0;
+};
+
+inline GraphCensus censusOf(const ExceptionInfo &Info) {
+  GraphCensus Census;
+  for (const ExceptionFunction &Function : Info.Functions) {
+    if (!Function.Itanium)
+      continue;
+    const ItaniumEHInfo &LSDA = *Function.Itanium;
+    ++Census.Records;
+    Census.CallSites += LSDA.CallSites.size();
+    Census.TypeTableEntries += LSDA.TypeTable.size();
+    for (const ItaniumAction &Action : LSDA.Actions)
+      if (Action.isCatch())
+        ++Census.CatchClauses;
+
+    std::set<va_t> Pads;
+    for (const ItaniumCallSite &Site : LSDA.CallSites) {
+      if (Site.LandingPadVA == 0)
+        continue;
+      Pads.insert(Site.LandingPadVA);
+    }
+    Census.LandingPads += Pads.size();
+  }
+  return Census;
+}
+
+} // namespace neverd::ada_d_corpus_test
+
+#endif

--- a/unittests/lift/eh/ItaniumEHEmitterTests.cpp
+++ b/unittests/lift/eh/ItaniumEHEmitterTests.cpp
@@ -83,6 +83,63 @@ MedFunc makeSingleCallCleanupFunction(llvm::StringRef Name, va_t FunctionVA,
   return Func;
 }
 
+TEST(ItaniumEHEmitter, PreservesAdaAndDAddressFormPersonalities) {
+  struct PersonalityCase {
+    ExceptionPersonality Personality;
+    const char *Symbol;
+  };
+  constexpr PersonalityCase Cases[] = {
+      {ExceptionPersonality::GnatPersonalityV0, "__gnat_personality_v0"},
+      {ExceptionPersonality::GnatPersonalitySEH0, "__gnat_personality_seh0"},
+      {ExceptionPersonality::DmdPersonalityV0, "__dmd_personality_v0"},
+      {ExceptionPersonality::DRuntimeEhPersonality, "_d_eh_personality"},
+      {ExceptionPersonality::GdcPersonalityV0, "__gdc_personality_v0"},
+      {ExceptionPersonality::GdcPersonalitySEH0, "__gdc_personality_seh0"},
+  };
+
+  for (size_t I = 0; I < std::size(Cases); ++I) {
+    const PersonalityCase &Case = Cases[I];
+    SCOPED_TRACE(Case.Symbol);
+    const va_t FunctionVA = 0x100001000 + I * 0x1000;
+    const va_t MayThrowVA = 0x100010000 + I * 0x1000;
+    MedFunc Func = makeSingleCallCleanupFunction(
+        "native_language_personality_" + std::to_string(I), FunctionVA,
+        MayThrowVA);
+    Func.ExceptionMetadata->Personality = Case.Personality;
+
+    llvm::LLVMContext Context;
+    auto Module = MedLLVMEmitter().emit(
+        {Func}, Context, "native-language-personality", Arch::AArch64,
+        {{MayThrowVA, "may_throw"}}, nullptr, BinaryFormat::ELF);
+    ASSERT_NE(Module, nullptr);
+    llvm::Function *Emitted = Module->getFunction(Func.Name);
+    ASSERT_NE(Emitted, nullptr);
+    ASSERT_TRUE(Emitted->hasPersonalityFn());
+    const auto *Personality = llvm::dyn_cast<llvm::Function>(
+        Emitted->getPersonalityFn()->stripPointerCasts());
+    ASSERT_NE(Personality, nullptr);
+    EXPECT_EQ(Personality->getName(), Case.Symbol);
+
+    const llvm::MDNode *Native =
+        Emitted->getMetadata(language_eh_md::ItaniumAttachment);
+    ASSERT_NE(Native, nullptr);
+    const auto *RecordedSymbol =
+        llvm::dyn_cast<llvm::MDString>(Native->getOperand(0).get());
+    ASSERT_NE(RecordedSymbol, nullptr);
+    EXPECT_EQ(RecordedSymbol->getString(), Case.Symbol);
+
+    unsigned Invokes = 0;
+    unsigned LandingPads = 0;
+    for (llvm::BasicBlock &Block : *Emitted)
+      for (llvm::Instruction &Instruction : Block) {
+        Invokes += llvm::isa<llvm::InvokeInst>(Instruction);
+        LandingPads += llvm::isa<llvm::LandingPadInst>(Instruction);
+      }
+    EXPECT_EQ(Invokes, 1u);
+    EXPECT_EQ(LandingPads, 1u);
+  }
+}
+
 TEST(ItaniumEHEmitter, UsesTheOriginalIndirectTypeInfoSlotForCatchClauses) {
   constexpr va_t FunctionVA = 0x100001000;
   constexpr va_t MayThrowVA = 0x100001100;

--- a/unittests/lift/language/LanguageEHItaniumTests.cpp
+++ b/unittests/lift/language/LanguageEHItaniumTests.cpp
@@ -115,11 +115,13 @@ TEST(ItaniumLSDA, DecodesCallSitesActionsAndTypes) {
   Req.LSDAVA = LSDAVA;
   Req.FunctionStart = FuncVA;
   Req.FunctionEnd = FuncVA + 0x100;
+  Req.Personality = ExceptionPersonality::GxxPersonalityV0;
   LSDAParseResult Result = parseLSDA(Img, Req, PointerBases{});
 
   ASSERT_TRUE(Result.Info.has_value());
   EXPECT_EQ(Result.ParseStatus, ExceptionParseStatus::Complete);
   const ItaniumEHInfo &Info = *Result.Info;
+  EXPECT_EQ(Info.TypeTableEntryKind, ItaniumTypeTableEntryKind::CxxRTTI);
 
   EXPECT_EQ(Info.LandingPadBase, FuncVA);
   ASSERT_EQ(Info.CallSites.size(), 3u);
@@ -149,6 +151,53 @@ TEST(ItaniumLSDA, DecodesCallSitesActionsAndTypes) {
   EXPECT_EQ(Info.TypeTable[0].TypeName, "i");
   EXPECT_FALSE(Info.TypeTable[0].IsCatchAll);
   EXPECT_FALSE(Info.isCleanupOnly());
+}
+
+TEST(ItaniumLSDA, KeepsAdaAndDTypeDescriptorsOpaque) {
+  const va_t FuncVA = kTextVA + 0x100;
+  const va_t LSDAVA = kDataVA + 0x200;
+  const va_t DescriptorVA = kDataVA + 0x600;
+
+  for (ExceptionPersonality Personality :
+       {ExceptionPersonality::GnatPersonalityV0,
+        ExceptionPersonality::DmdPersonalityV0,
+        ExceptionPersonality::DRuntimeEhPersonality,
+        ExceptionPersonality::GdcPersonalityV0}) {
+    SCOPED_TRACE(getExceptionPersonalityName(Personality));
+    BinaryImage Img = makeImage();
+
+    // Both language runtimes put an opaque descriptor in this slot: GNAT uses
+    // an Exception_Id and D uses a ClassInfo.  Make its second word look like a
+    // valid std::type_info name pointer so an accidental RTTI interpretation
+    // produces a convincing but false answer instead of merely failing.
+    ByteBuilder Descriptor;
+    Descriptor.u64(kDataVA + 0x700);
+    Descriptor.u64(kDataVA + 0x680);
+    writeData(Img, DescriptorVA, Descriptor.data());
+    constexpr char ForgedRTTIName[] = "forged_rtti_name";
+    writeData(Img, kDataVA + 0x680,
+              std::vector<uint8_t>(ForgedRTTIName,
+                                   ForgedRTTIName + sizeof(ForgedRTTIName)));
+
+    LSDABytes Table = buildCatchLSDA(LSDAVA, FuncVA, DescriptorVA);
+    writeData(Img, LSDAVA, Table.Bytes);
+
+    LSDAParseRequest Req;
+    Req.LSDAVA = LSDAVA;
+    Req.FunctionStart = FuncVA;
+    Req.FunctionEnd = FuncVA + 0x100;
+    Req.Personality = Personality;
+    LSDAParseResult Result = parseLSDA(Img, Req, PointerBases{});
+
+    ASSERT_TRUE(Result.Info.has_value());
+    EXPECT_EQ(Result.ParseStatus, ExceptionParseStatus::Complete);
+    EXPECT_EQ(Result.Info->TypeTableEntryKind,
+              ItaniumTypeTableEntryKind::OpaqueDescriptor);
+    ASSERT_EQ(Result.Info->TypeTable.size(), 1u);
+    EXPECT_EQ(Result.Info->TypeTable[0].TypeInfoVA, DescriptorVA);
+    EXPECT_TRUE(Result.Info->TypeTable[0].TypeName.empty());
+    EXPECT_FALSE(Result.Info->TypeTable[0].IsCatchAll);
+  }
 }
 
 TEST(ItaniumLSDA, FollowsAnActionChainThatPointsBackwards) {


### PR DESCRIPTION
## Summary
- Treat GNAT `Exception_Id`/`Exception_Data` and D `ClassInfo` type-table slots as opaque descriptors. The LSDA parser no longer follows them as `std::type_info`.
- Lower address-form GNAT, GDC, DMD, and LDC personalities to LLVM `personality` plus `invoke`/`landingpad`. SJLJ personalities stay unlowered.
- Consume the twelve published GNAT/GDC/DMD/LDC cells for the parseable-LSDA and opaque-descriptor layers. D `scope (exit)` stays a producer/manifest claim: DMD encodes it as `catch(Throwable)`, not a cleanup-only pad.
- Document the three layers separately: parseable LSDA, native reconstruction, and corpus-proven. Personality recognition is not Ada or D exception support.

## Test plan
- [x] `NeverDLanguageEHTests --gtest_filter='ItaniumLSDA.*'`
- [x] `NeverDLiftTests --gtest_filter='ItaniumEHEmitter.*'`
- [x] `NeverDAdaDEHCorpusManifestTests`
- [x] `NeverDAdaDEHCorpusTests` against testbins `9d9362d`
- [ ] CI on this PR