### PR TITLE
fix(lift): harden ABI/provenance and cache frame-reload proofs

### DIFF
--- a/include/neverd/backend/llvm/MedLLVMEmitterCore.h
+++ b/include/neverd/backend/llvm/MedLLVMEmitterCore.h
@@ -1584,6 +1584,23 @@ private:
 
   using AddressProvenanceVarKey =
       std::tuple<int, int, int, int, int, uint16_t, uint64_t, int, uint64_t>;
+  struct FrameReloadCacheKey {
+    va_t Addr = InvalidVA;
+    int OriginSeq = -1;
+    uint16_t Width = 0;
+    AddressProvenanceVarKey Address = {};
+    AddressProvenanceVarKey Output = {};
+
+    bool operator<(const FrameReloadCacheKey &Other) const {
+      return std::tie(Addr, OriginSeq, Width, Address, Output) <
+             std::tie(Other.Addr, Other.OriginSeq, Other.Width,
+                       Other.Address, Other.Output);
+    }
+  };
+  struct FrameReloadCacheEntry {
+    bool Proven = false;
+    std::vector<MedVar> Sources;
+  };
   struct IndexedGlobalBaseProof {
     bool Proven = false;
     uint64_t Base = 0;
@@ -1685,7 +1702,11 @@ private:
   mutable std::map<
       std::tuple<AddressProvenanceVarKey, bool, AddressProvenanceVarKey>, bool>
       StableOffsetCache;
-
+  // A failed select/PHI table audit has no LLVM value to cache, but its
+  // MedIR result is independent of the current IRBuilder.
+  mutable const MedFunc *SelectMergeFailureCacheFor = nullptr;
+  mutable std::set<std::tuple<AddressProvenanceVarKey, uint16_t, bool>>
+      SelectMergeFailureCache;
   // Cache of writable-segment base VAs that contain at least one already-
   // symbolized writable-reloc pointer constant (see
   // hasSymbolizedWritableSibling); keyed on the current function.  Mutable so
@@ -1753,6 +1774,12 @@ private:
   mutable llvm::DenseMap<std::pair<int64_t, int>, bool> FrameDerivedCache;
   mutable const MedFunc *FrameAddressCacheFor = nullptr;
   mutable llvm::DenseMap<std::pair<int64_t, int>, bool> FrameAddressCache;
+  mutable const MedFunc *FrameReloadCacheFor = nullptr;
+  mutable uint64_t FrameReloadCacheGeneration = 0;
+  mutable std::map<FrameReloadCacheKey, FrameReloadCacheEntry>
+      FrameReloadCache;
+  mutable uint64_t FrameReloadProofBuilds = 0;
+  mutable uint64_t FrameReloadProofHits = 0;
 
   // Per-function memoized results of the stack-slot address predicates, dropped
   // when CurMedFunc changes (see ensureAddrPredCache).  Each answer depends

--- a/include/neverd/backend/llvm/MedLLVMEmitterCore.h
+++ b/include/neverd/backend/llvm/MedLLVMEmitterCore.h
@@ -1653,12 +1653,37 @@ private:
     bool Proven = false;
     std::vector<MedVar> Sources;
   };
+  struct FrameReloadWrite {
+    std::size_t Index = 0;
+    MedVar Address;
+    MedVar Value;
+    uint16_t Size = 0;
+    bool HasAddress = false;
+    bool HasValue = false;
+    bool IsStore = false;
+  };
+  struct FrameReloadBlock {
+    std::vector<int> Successors;
+    std::set<int> StructuralPreds;
+    std::vector<FrameReloadWrite> Writes;
+  };
+  struct FrameReloadLoadSite {
+    int BlockId = -1;
+    std::size_t Index = 0;
+  };
+  struct FrameReloadAnalysis {
+    bool Valid = false;
+    int EntryBlockId = -1;
+    std::map<int, FrameReloadBlock> Blocks;
+    std::map<FrameReloadOccurrenceKey, FrameReloadLoadSite> Loads;
+  };
   enum class FrameReloadCacheState { Empty, Building, Ready };
 
   static std::optional<FrameReloadOccurrenceKey>
   frameReloadOccurrenceKey(const MedOp &Load);
   void invalidateFrameReloadSourceCache() const;
   bool ensureFrameReloadOccurrenceIndex() const;
+  void ensureFrameReloadAnalysis() const;
 
   // Stable, exact-occurrence memoization for all-path frame reload proofs.
   // The cache never retains MedOp pointers: a key records the complete load
@@ -1677,6 +1702,12 @@ private:
   mutable bool FrameReloadBuildSawReentrantQuery = false;
   mutable std::map<FrameReloadOccurrenceKey, FrameReloadSourceResult>
       FrameReloadSourceCache;
+  // Immutable per-function write/CFG facts reused by every occurrence proof.
+  // Result cache identity remains the upstream stable occurrence key.
+  mutable bool FrameReloadAnalysisBuilt = false;
+  mutable FrameReloadAnalysis FrameReloadIndex;
+  mutable uint64_t FrameReloadAnalysisBuilds = 0;
+  mutable uint64_t FrameReloadSourceGeneration = 0;
 
   // Exact, cycle-safe propagation of incomplete architectural address
   // fragments for the function currently being emitted. Observable sinks and

--- a/include/neverd/ir/med/MedABIPass.h
+++ b/include/neverd/ir/med/MedABIPass.h
@@ -53,13 +53,14 @@ int regToArgIdx(uint64_t RegOff, Arch TheArch);
 void recoverCallAbi(
     MedFunc &Func, Arch TheArch, const std::map<va_t, std::string> &FuncNames,
     const BinaryImage *Img = nullptr,
-    const std::map<va_t, int> *CalleeRegArity = nullptr,
-    const std::map<va_t, int> *CalleeTotalArity = nullptr,
+    std::map<va_t, int> *CalleeRegArity = nullptr,
+    std::map<va_t, int> *CalleeTotalArity = nullptr,
     const std::map<va_t, int> *CalleeFPArity = nullptr,
     const std::map<va_t, bool> *CalleeReturnsVec = nullptr,
     const std::map<va_t, std::vector<uint64_t>> *CalleeFPRegs = nullptr,
     const std::map<va_t, bool> *CalleeHasSret = nullptr,
-    const std::map<va_t, bool> *CalleeIsVariadic = nullptr);
+    std::map<va_t, bool> *CalleeIsVariadic = nullptr,
+    const std::map<va_t, bool> *CalleeConsumesVaList = nullptr);
 
 // Finalize the overflow stack parameters of every variadic callee once all call
 // sites have been recovered.  A variadic function's va_arg overflow reads land

--- a/include/neverd/libc/LibCStdio.h
+++ b/include/neverd/libc/LibCStdio.h
@@ -97,6 +97,9 @@ inline constexpr auto kStdioArity = std::to_array<LibCArityEntry>({
     {"setbuf", {2, 0}},  {"setvbuf", {4, 0}},  {"ungetc", {2, 0}},
     {"tmpfile", {0, 0}}, {"popen", {2, 0}},    {"pclose", {1, 0}},
     {"putw", {2, 0}},    {"getw", {1, 0}},
+    {"vdprintf", {2, 0}}, {"vfprintf", {3, 0}}, {"vfscanf", {2, 0}},
+    {"vprintf", {2, 0}},  {"vscanf", {1, 0}},   {"vsnprintf", {3, 0}},
+    {"vsprintf", {2, 0}}, {"vsscanf", {2, 0}},
 });
 
 } // namespace neverd::libc

--- a/include/neverd/libc/LibCVaListConsumers.inc
+++ b/include/neverd/libc/LibCVaListConsumers.inc
@@ -1,6 +1,7 @@
 // Irregular va_list-consuming functions with no printf/scanf suffix.
 // Included by LibCCallTraits.cpp with LIBC_VA_LIST_CONSUMER defined.
 
+LIBC_VA_LIST_CONSUMER("vasprintf")
 LIBC_VA_LIST_CONSUMER("vsyslog")
 LIBC_VA_LIST_CONSUMER("verr")
 LIBC_VA_LIST_CONSUMER("verrx")

--- a/lib/backend/codegen/ELF/ELFARMEHABIPatch.cpp
+++ b/lib/backend/codegen/ELF/ELFARMEHABIPatch.cpp
@@ -530,10 +530,11 @@ llvm::Error collectGeneratedRecords(const CompiledImage &Compiled,
       } else if ((Word1 & kCompactBit) != 0) {
         if ((Word1 & kCompactVendorMask) != 0 ||
             ((Word1 >> kCompactIndexShift) & 0xF) != 0 ||
-            !validateInlineOpcodeWord(Word1))
+            !validateInlineOpcodeWord(Word1)) {
           return patchError("a regenerated .ARM.exidx entry names a "
                             "personality routine or opcode program that "
                             "cannot be encoded inline");
+        }
         Record.Model = ELFARMEHABIModel::Inline;
         for (size_t Byte = kInlineOpcodeBytes; Byte-- > 0;)
           Record.Opcodes.push_back(static_cast<uint8_t>(Word1 >> (Byte * 8)));

--- a/lib/backend/llvm/data/MedLLVMIndexedGlobal.cpp
+++ b/lib/backend/llvm/data/MedLLVMIndexedGlobal.cpp
@@ -671,6 +671,22 @@ MedLLVMEmitter::tryResolveInductionGlobalPtr(const MedVar &AddrVar,
     return TRI.isSubRegOf(AV.RegOff, AV.Size, BV.RegOff, BV.Size) ||
            TRI.isSubRegOf(BV.RegOff, BV.Size, AV.RegOff, AV.Size);
   };
+  auto isSelectArmComponent = [&](const PhiNode &Phi,
+                                  const MedVar &Arm) {
+    if (Phi.Output == Arm)
+      return true;
+    const PhiNode *ArmPhi = findPhi(Arm);
+    return ArmPhi && inSameForwardingComponent(&Phi, ArmPhi);
+  };
+  auto isSelectArmPair = [&](const PhiNode &A, const PhiNode &B) {
+    return std::any_of(SelectBasePairs.begin(), SelectBasePairs.end(),
+                       [&](const auto &Pair) {
+                         return (isSelectArmComponent(A, Pair.first) &&
+                                 isSelectArmComponent(B, Pair.second)) ||
+                                (isSelectArmComponent(A, Pair.second) &&
+                                 isSelectArmComponent(B, Pair.first));
+                       });
+  };
 
   llvm::Constant *ProvenRun = nullptr;
   uint64_t ProvenRunStart = 0;
@@ -683,9 +699,11 @@ MedLLVMEmitter::tryResolveInductionGlobalPtr(const MedVar &AddrVar,
     for (const PhiBaseEvidence &Item : Evidence) {
       // Multiple table-bearing recurrence candidates are only one pointer
       // component when their outputs are overlapping register aliases. Two
-      // independent pointer PHIs under ADD/SUB are not an address base+index.
+      // independent pointer PHIs under ADD/SUB are not a base+index. Exact
+      // SELECT arms are allowed only when both stay in one forwarding component.
       if (Item.Phi != PrimaryPhi && !isRegisterAlias(*PrimaryPhi, *Item.Phi) &&
-          !inSameForwardingComponent(PrimaryPhi, Item.Phi)) {
+          !inSameForwardingComponent(PrimaryPhi, Item.Phi) &&
+          !isSelectArmPair(*PrimaryPhi, *Item.Phi)) {
         failAmbiguousPhi(*Item.Phi);
         return nullptr;
       }
@@ -1033,7 +1051,58 @@ MedLLVMEmitter::tryResolveIndexedGlobalPtr(const MedVar &AddrVar,
   if (!Def || Def->NumInputs < 2 ||
       (Def->Opcode != NdOp::INT_ADD && Def->Opcode != NdOp::INT_SUB))
     return nullptr;
-
+  auto isBoundedScalarLookup = [&](const MedVar &Value) {
+    const MedOp *Load = lookupDef(Value);
+    if (!Load || Load->Opcode != NdOp::LOAD || Load->NumInputs < 1)
+      return false;
+    auto sameValue = [](const MedVar &A, const MedVar &B) {
+      return !A.isConst() && !B.isConst() && A.Kind == B.Kind &&
+             A.Id == B.Id && A.SSAVer == B.SSAVer;
+    };
+    bool HasSmallBound = false;
+    for (const MedBlock &Block : CurMedFunc->Blocks)
+      for (const MedOp &Use : Block.Ops)
+        for (uint8_t I = 0; I < Use.NumInputs; ++I) {
+          if (!sameValue(Use.Inputs[I], Value))
+            continue;
+          const uint8_t Other = I ^ 1u;
+          const bool IsCompare =
+              Use.Opcode == NdOp::INT_EQUAL ||
+              Use.Opcode == NdOp::INT_NOTEQUAL ||
+              Use.Opcode == NdOp::INT_LESS ||
+              Use.Opcode == NdOp::INT_SLESS ||
+              Use.Opcode == NdOp::INT_LESSEQUAL ||
+              Use.Opcode == NdOp::INT_SLESSEQUAL;
+          if (IsCompare) {
+            if (Use.NumInputs >= 2 && Use.Inputs[Other].isConst() &&
+                Use.Inputs[Other].ConstVal <= 0x100000)
+              HasSmallBound = true;
+            continue;
+          }
+          switch (Use.Opcode) {
+          case NdOp::COPY:
+          case NdOp::SUBBYTES:
+          case NdOp::INT_ZEXT:
+          case NdOp::INT_SEXT:
+          case NdOp::INT_ADD:
+          case NdOp::INT_SUB:
+          case NdOp::INT_AND:
+          case NdOp::INT_OR:
+          case NdOp::INT_XOR:
+          case NdOp::INT_LEFT:
+          case NdOp::INT_RIGHT:
+          case NdOp::INT_ASHR:
+          case NdOp::INT_CARRY:
+          case NdOp::INT_SOVF:
+          case NdOp::INT_SBOR:
+          case NdOp::BOOL_NOT:
+            continue;
+          default:
+            return false;
+          }
+        }
+    return HasSmallBound;
+  };
   // Decompose the address into one global base constant plus the runtime index
   // addends.  Handles both the one-level `INT_ADD(base,index)` form and a base
   // nested under multi-dimensional indexing (`base + row*stride + col`).
@@ -1049,7 +1118,8 @@ MedLLVMEmitter::tryResolveIndexedGlobalPtr(const MedVar &AddrVar,
   if (Def->Opcode == NdOp::INT_SUB && !traceSSAConst(Def->Inputs[1]) &&
       Def->Output.Size != 0 && Def->Inputs[0].Size != 0 &&
       Def->Output.Size >= Def->Inputs[0].Size &&
-      valueIsStableAddressOffset(Def->Inputs[1]) &&
+      (valueIsStableAddressOffset(Def->Inputs[1]) ||
+       isBoundedScalarLookup(Def->Inputs[1])) &&
       collectIndexedGlobalBase(Def->Inputs[0], Base, HaveBase, IdxTerms,
                                /*Depth=*/0, FailClosed) &&
       HaveBase)
@@ -1089,7 +1159,8 @@ MedLLVMEmitter::tryResolveIndexedGlobalPtr(const MedVar &AddrVar,
   for (const auto &T : IdxTerms) {
     if (varIsFrameDerived(T))
       return nullptr;
-    if (!valueIsStableAddressOffset(T)) {
+    if (!valueIsStableAddressOffset(T) &&
+        !isBoundedScalarLookup(T)) {
       if (FailClosed) {
         if (!FatalDataPointerResolution)
           syncError() << "med_llvm_emitter: read-only table address "

--- a/lib/backend/llvm/data/MedLLVMLiteralTable.cpp
+++ b/lib/backend/llvm/data/MedLLVMLiteralTable.cpp
@@ -999,7 +999,13 @@ llvm::Value *MedLLVMEmitter::tryResolveSelectMergeTable(
     // accepts multiply/shift/flag-expanded induction DAGs, but rejects any
     // feasible data/code-address leaf, mixed PHI, incomplete frame reload, or
     // relocatable constant, so a second base cannot hide behind this shortcut.
-    if (valueIsStableAddressOffset(V))
+    const MedOp *Def = findDef(V);
+    const bool IsForwardingWrapper =
+        Def && (Def->Opcode == NdOp::COPY ||
+                Def->Opcode == NdOp::INT_ZEXT ||
+                Def->Opcode == NdOp::INT_SEXT ||
+                Def->Opcode == NdOp::SUBBYTES);
+    if (!IsForwardingWrapper && valueIsStableAddressOffset(V))
       return BaseProof::NoBase;
     auto Key = std::make_tuple(static_cast<int>(V.Kind), V.Id, V.SSAVer);
     if (!Seen.insert(Key).second)
@@ -1030,7 +1036,6 @@ llvm::Value *MedLLVMEmitter::tryResolveSelectMergeTable(
       return BaseProof::HasBase;
     }
 
-    const MedOp *Def = findDef(V);
     bool SawLoad = false;
     bool SawArithmetic = false;
     uint16_t OriginSize = V.Size;

--- a/lib/backend/llvm/data/MedLLVMSpillPredicate.cpp
+++ b/lib/backend/llvm/data/MedLLVMSpillPredicate.cpp
@@ -669,6 +669,9 @@ void MedLLVMEmitter::invalidateFrameReloadSourceCache() const {
   FrameReloadSourceState = FrameReloadCacheState::Empty;
   FrameReloadBuildSawReentrantQuery = false;
   FrameReloadSourceCache.clear();
+  FrameReloadAnalysisBuilt = false;
+  FrameReloadIndex = {};
+  ++FrameReloadSourceGeneration;
 }
 
 bool MedLLVMEmitter::ensureFrameReloadOccurrenceIndex() const {
@@ -709,6 +712,83 @@ bool MedLLVMEmitter::ensureFrameReloadOccurrenceIndex() const {
   AmbiguousFrameReloadOccurrences = std::move(NextAmbiguous);
   FrameReloadOccurrenceIndexState = FrameReloadCacheState::Ready;
   return true;
+}
+void MedLLVMEmitter::ensureFrameReloadAnalysis() const {
+  if (!CurMedFunc || FrameReloadAnalysisBuilt)
+    return;
+  FrameReloadAnalysisBuilt = true;
+  ++FrameReloadAnalysisBuilds;
+  const MedFunc &Func = *CurMedFunc;
+  auto isMemoryWrite = [](NdOp Opcode) {
+    return Opcode == NdOp::STORE || Opcode == NdOp::ATOMIC_XCHG ||
+           Opcode == NdOp::ATOMIC_ADD || Opcode == NdOp::ATOMIC_CMPXCHG;
+  };
+  std::map<int, std::set<int>> DeclaredPreds;
+  for (const MedBlock &Block : Func.Blocks) {
+    auto [It, Inserted] = FrameReloadIndex.Blocks.emplace(
+        Block.Id, FrameReloadBlock{});
+    if (!Inserted)
+      return;
+    FrameReloadBlock &Indexed = It->second;
+    if (Block.StartAddr == Func.Entry) {
+      if (FrameReloadIndex.EntryBlockId >= 0)
+        return;
+      FrameReloadIndex.EntryBlockId = Block.Id;
+    }
+    Indexed.Successors = Block.Succs;
+    for (const ExceptionalEdge &Edge : Block.ExceptionalSuccs)
+      if (Edge.BlockId >= 0)
+        Indexed.Successors.push_back(Edge.BlockId);
+    auto &Declared = DeclaredPreds[Block.Id];
+    Declared.insert(Block.Preds.begin(), Block.Preds.end());
+    for (const ExceptionalEdge &Edge : Block.ExceptionalPreds)
+      if (Edge.BlockId >= 0)
+        Declared.insert(Edge.BlockId);
+    for (std::size_t I = 0; I < Block.Ops.size(); ++I) {
+      const MedOp &Op = Block.Ops[I];
+      if (isMemoryWrite(Op.Opcode)) {
+        FrameReloadWrite Write;
+        Write.Index = I;
+        Write.HasAddress = Op.NumInputs >= 1;
+        Write.IsStore = Op.Opcode == NdOp::STORE;
+        if (Write.HasAddress)
+          Write.Address = Op.Inputs[0];
+        if (Write.IsStore && Op.NumInputs >= 2) {
+          Write.HasValue = true;
+          Write.Value = Op.Inputs[1];
+          Write.Size = Op.Inputs[1].Size;
+        } else {
+          Write.HasValue = Op.Output.Size != 0;
+          Write.Value = Op.Output;
+          Write.Size = Op.Output.Size;
+        }
+        Indexed.Writes.push_back(std::move(Write));
+      }
+      if (auto Key = frameReloadOccurrenceKey(Op)) {
+        FrameReloadLoadSite Site;
+        Site.BlockId = Block.Id;
+        Site.Index = I;
+        if (!FrameReloadIndex.Loads.emplace(*Key, std::move(Site)).second)
+          return;
+      }
+    }
+  }
+  if (FrameReloadIndex.EntryBlockId < 0)
+    return;
+  for (const auto &[Id, Block] : FrameReloadIndex.Blocks) {
+    for (int SuccId : Block.Successors) {
+      auto It = FrameReloadIndex.Blocks.find(SuccId);
+      if (It == FrameReloadIndex.Blocks.end())
+        return;
+      It->second.StructuralPreds.insert(Id);
+    }
+  }
+  for (const auto &[Id, Block] : FrameReloadIndex.Blocks) {
+    auto It = DeclaredPreds.find(Id);
+    if (It == DeclaredPreds.end() || It->second != Block.StructuralPreds)
+      return;
+  }
+  FrameReloadIndex.Valid = true;
 }
 
 bool MedLLVMEmitter::collectFrameReloadSources(
@@ -818,68 +898,17 @@ bool MedLLVMEmitter::collectFrameReloadSourcesUncached(
   if (!Target)
     return false;
 
-  std::map<int, const MedBlock *> BlocksById;
-  const MedBlock *EntryBlock = nullptr;
-  const MedBlock *LoadBlock = nullptr;
-  size_t LoadIndex = 0;
-  for (const MedBlock &Block : CurMedFunc->Blocks) {
-    if (!BlocksById.emplace(Block.Id, &Block).second)
-      return false;
-    if (Block.StartAddr == CurMedFunc->Entry) {
-      if (EntryBlock)
-        return false;
-      EntryBlock = &Block;
-    }
-    for (size_t I = 0; I < Block.Ops.size(); ++I)
-      if (&Block.Ops[I] == &Load) {
-        if (LoadBlock)
-          return false;
-        LoadBlock = &Block;
-        LoadIndex = I;
-      }
-  }
-  if (!EntryBlock || !LoadBlock)
+  ensureFrameReloadAnalysis();
+  if (!FrameReloadIndex.Valid)
     return false;
+  auto Key = frameReloadOccurrenceKey(Load);
+  if (!Key)
+    return false;
+  auto SiteIt = FrameReloadIndex.Loads.find(*Key);
+  if (SiteIt == FrameReloadIndex.Loads.end())
+    return false;
+  const FrameReloadLoadSite Site = SiteIt->second;
 
-  // Preds is cached IR metadata, not authority for reachability.  Reconstruct
-  // the incoming relation from every ordinary/exceptional successor and
-  // require the two views to agree before proving an all-path reaching store.
-  // A malformed or stale predecessor list must not hide an uninitialized
-  // bypass and turn a later table-looking STORE into pointer provenance.
-  std::map<int, std::set<int>> StructuralPreds;
-  for (const auto &[Id, Block] : BlocksById) {
-    (void)Block;
-    StructuralPreds.emplace(Id, std::set<int>{});
-  }
-  for (const auto &[Id, Block] : BlocksById) {
-    for (int SuccId : Block->Succs) {
-      auto It = StructuralPreds.find(SuccId);
-      if (It == StructuralPreds.end())
-        return false;
-      It->second.insert(Id);
-    }
-    for (const ExceptionalEdge &Edge : Block->ExceptionalSuccs) {
-      if (Edge.BlockId < 0)
-        continue;
-      auto It = StructuralPreds.find(Edge.BlockId);
-      if (It == StructuralPreds.end())
-        return false;
-      It->second.insert(Id);
-    }
-  }
-  for (const auto &[Id, Block] : BlocksById) {
-    std::set<int> Declared(Block->Preds.begin(), Block->Preds.end());
-    for (const ExceptionalEdge &Edge : Block->ExceptionalPreds)
-      if (Edge.BlockId >= 0)
-        Declared.insert(Edge.BlockId);
-    if (Declared != StructuralPreds[Id])
-      return false;
-  }
-
-  auto isMemoryWrite = [](NdOp Opcode) {
-    return Opcode == NdOp::STORE || Opcode == NdOp::ATOMIC_XCHG ||
-           Opcode == NdOp::ATOMIC_ADD || Opcode == NdOp::ATOMIC_CMPXCHG;
-  };
   auto overlaps = [](int64_t A, uint16_t ASize, int64_t B, uint16_t BSize) {
     if (ASize == 0 || BSize == 0)
       return true;
@@ -920,27 +949,22 @@ bool MedLLVMEmitter::collectFrameReloadSourcesUncached(
       addUnique(Dst.Values, Value);
     return !sameState(Before, Dst);
   };
-  auto transfer = [&](const MedBlock &Block, size_t Boundary,
+  auto transfer = [&](const FrameReloadBlock &Block, std::size_t Boundary,
                       ReachingState State) {
-    if (!State.Reachable || Boundary > Block.Ops.size()) {
-      State.Invalid |= Boundary > Block.Ops.size();
+    if (!State.Reachable)
       return State;
-    }
-    for (size_t I = 0; I < Boundary; ++I) {
-      const MedOp &Op = Block.Ops[I];
-      if (!isMemoryWrite(Op.Opcode))
-        continue;
-      if (Op.NumInputs < 1) {
+    for (const FrameReloadWrite &Write : Block.Writes) {
+      if (Write.Index >= Boundary)
+        break;
+      if (!Write.HasAddress) {
         State.Invalid = true;
         State.Values.clear();
         continue;
       }
-      const MedVar &WriteAddr = Op.Inputs[0];
+      const MedVar &WriteAddr = Write.Address;
       if (!varMayBeFrameAddress(WriteAddr))
         continue;
-      uint16_t WriteSize = Op.Opcode == NdOp::STORE && Op.NumInputs >= 2
-                               ? Op.Inputs[1].Size
-                               : Op.Output.Size;
+      const uint16_t WriteSize = Write.Size;
       const auto WriteKey = canonicalFrameSlotKey(WriteAddr);
       // A frame-derived write whose slot cannot be canonicalized, or whose
       // root differs from the reload's root, may still alias after an
@@ -949,24 +973,24 @@ bool MedLLVMEmitter::collectFrameReloadSourcesUncached(
       if (!WriteKey || WriteKey->first != Target->first) {
         const bool ProvenDisjoint =
             !WriteKey &&
-            frameAccessesProvenDisjoint(WriteAddr, WriteSize, Load.Inputs[0],
-                                        Load.Output.Size);
+            frameAccessesProvenDisjoint(WriteAddr, WriteSize,
+                                         Load.Inputs[0], Load.Output.Size);
         if (ProvenDisjoint)
           continue;
         State.Invalid = true;
         State.Values.clear();
         continue;
       }
-
       if (!overlaps(WriteKey->second, WriteSize, Target->second,
                     Load.Output.Size))
         continue;
-      if (Op.Opcode == NdOp::STORE && Op.NumInputs >= 2 && WriteSize != 0 &&
-          WriteKey->second == Target->second && WriteSize == Load.Output.Size) {
+      if (Write.IsStore && Write.HasValue && WriteSize != 0 &&
+          WriteKey->second == Target->second &&
+          WriteSize == Load.Output.Size) {
         State.Uninitialized = false;
         State.Invalid = false;
         State.Values.clear();
-        addUnique(State.Values, Op.Inputs[1]);
+        addUnique(State.Values, Write.Value);
         continue;
       }
       State.Uninitialized = false;
@@ -976,47 +1000,43 @@ bool MedLLVMEmitter::collectFrameReloadSourcesUncached(
     return State;
   };
 
-  // Forward may-reach dataflow over the exact slot.  Unlike a recursive
-  // backwards walk, this reaches a fixed point across loop back-edges and
-  // therefore distinguishes a preheader definition from a STORE that occurs
-  // only after the LOAD and can affect later iterations.
+  // Forward may-reach dataflow over the exact slot. The immutable snapshot
+  // keeps CFG and write construction out of this per-occurrence proof.
   std::map<int, ReachingState> InStates;
   std::map<int, ReachingState> OutStates;
   ReachingState Entry;
   Entry.Reachable = true;
   Entry.Uninitialized = true;
-  InStates[EntryBlock->Id] = Entry;
-  std::vector<int> Work{EntryBlock->Id};
+  InStates[FrameReloadIndex.EntryBlockId] = Entry;
+  std::vector<int> Work{FrameReloadIndex.EntryBlockId};
   while (!Work.empty()) {
     int BlockId = Work.back();
     Work.pop_back();
-    auto BlockIt = BlocksById.find(BlockId);
-    if (BlockIt == BlocksById.end())
+    auto BlockIt = FrameReloadIndex.Blocks.find(BlockId);
+    if (BlockIt == FrameReloadIndex.Blocks.end())
       return false;
-    const MedBlock &Block = *BlockIt->second;
-    ReachingState Next = transfer(Block, Block.Ops.size(), InStates[BlockId]);
+    const FrameReloadBlock &Block = BlockIt->second;
+    ReachingState Next =
+        transfer(Block, std::numeric_limits<std::size_t>::max(),
+                 InStates[BlockId]);
     if (sameState(OutStates[BlockId], Next))
       continue;
     OutStates[BlockId] = Next;
 
-    auto propagate = [&](int SuccId) {
-      auto Succ = BlocksById.find(SuccId);
-      if (Succ == BlocksById.end())
+    for (int SuccId : Block.Successors) {
+      if (FrameReloadIndex.Blocks.find(SuccId) ==
+          FrameReloadIndex.Blocks.end())
         return false;
       if (mergeInto(InStates[SuccId], Next))
         Work.push_back(SuccId);
-      return true;
-    };
-    for (int SuccId : Block.Succs)
-      if (!propagate(SuccId))
-        return false;
-    for (const ExceptionalEdge &Edge : Block.ExceptionalSuccs)
-      if (Edge.BlockId >= 0 && !propagate(Edge.BlockId))
-        return false;
+    }
   }
 
+  auto LoadBlockIt = FrameReloadIndex.Blocks.find(Site.BlockId);
+  if (LoadBlockIt == FrameReloadIndex.Blocks.end())
+    return false;
   ReachingState AtLoad =
-      transfer(*LoadBlock, LoadIndex, InStates[LoadBlock->Id]);
+      transfer(LoadBlockIt->second, Site.Index, InStates[Site.BlockId]);
   if (!AtLoad.Reachable || AtLoad.Uninitialized || AtLoad.Invalid ||
       AtLoad.Values.empty())
     return false;

--- a/lib/backend/llvm/data/MedLLVMSymbolizedPtr.cpp
+++ b/lib/backend/llvm/data/MedLLVMSymbolizedPtr.cpp
@@ -306,14 +306,40 @@ MedLLVMEmitter::tryResolveReadOnlyDataPtr(const MedVar &AddrVar,
   // returns a clean non-match for a pure induction, but a mixed/malformed PHI
   // must stop here before a narrower resolver can select one convenient arm.
   bool SawAmbiguous = false;
-  if (auto *P = tryResolveSelectMergeTable(AddrVar, SizeHint, FailClosed,
-                                           Builder, &SawAmbiguous))
-    return P;
-  if (SawAmbiguous)
-    return nullptr;
-  if (auto *P =
-          tryResolveIndexedGlobalPtr(AddrVar, SizeHint, FailClosed, Builder))
-    return P;
+  const MedOp *Top = lookupDef(AddrVar);
+  auto isKnownReadOnlyBase = [&](const MedVar &Value) {
+    std::optional<uint64_t> VA =
+        Value.isConst() ? std::optional<uint64_t>(Value.ConstVal)
+                        : traceSSAConst(Value);
+    return VA && isMaterializableReadOnlyDataAddress(*VA);
+  };
+  const bool PreferIndexed =
+      Top && Top->Opcode == NdOp::INT_ADD && Top->NumInputs >= 2 &&
+      (isKnownReadOnlyBase(Top->Inputs[0]) ||
+       isKnownReadOnlyBase(Top->Inputs[1]));
+  if (PreferIndexed)
+    if (auto *P =
+        tryResolveIndexedGlobalPtr(AddrVar, SizeHint, FailClosed, Builder))
+      return P;
+  if (SelectMergeFailureCacheFor != CurMedFunc) {
+    SelectMergeFailureCacheFor = CurMedFunc;
+    SelectMergeFailureCache.clear();
+  }
+  const auto SelectMergeKey = std::make_tuple(
+      addressProvenanceVarKey(AddrVar), SizeHint, FailClosed);
+  if (!SelectMergeFailureCache.count(SelectMergeKey)) {
+    if (auto *P = tryResolveSelectMergeTable(AddrVar, SizeHint, FailClosed,
+                                             Builder, &SawAmbiguous))
+      return P;
+    if (SawAmbiguous)
+      return nullptr;
+    if (!FatalDataPointerResolution && !FatalCodePointerResolution)
+      SelectMergeFailureCache.insert(SelectMergeKey);
+  }
+  if (!PreferIndexed)
+    if (auto *P =
+        tryResolveIndexedGlobalPtr(AddrVar, SizeHint, FailClosed, Builder))
+      return P;
   if (auto *P = tryResolveLiteralPoolTable(AddrVar, SizeHint, Builder))
     return P;
   if (auto *P =
@@ -347,18 +373,36 @@ llvm::Value *MedLLVMEmitter::tryResolvePointerArg(const MedVar &AddrVar,
   // audits prevent a second base from being applied.
   if (Occurrence.Model == ConstantProvenanceSummary::ValueModel::Address) {
     bool SawAmbiguous = false;
-    if (llvm::Value *Merged = tryResolveSelectMergeTable(
-            AddrVar, /*SizeHint=*/0, FailClosed, Builder, &SawAmbiguous))
-      return Merged;
-    if (SawAmbiguous)
-      return nullptr;
+    if (SelectMergeFailureCacheFor != CurMedFunc) {
+      SelectMergeFailureCacheFor = CurMedFunc;
+      SelectMergeFailureCache.clear();
+    }
+    const auto SelectMergeKey = std::make_tuple(
+        addressProvenanceVarKey(AddrVar), uint16_t(0), FailClosed);
+    if (!SelectMergeFailureCache.count(SelectMergeKey)) {
+      if (llvm::Value *Merged = tryResolveSelectMergeTable(
+              AddrVar, /*SizeHint=*/0, FailClosed, Builder, &SawAmbiguous))
+        return Merged;
+      if (SawAmbiguous)
+        return nullptr;
+      if (!FatalDataPointerResolution && !FatalCodePointerResolution)
+        SelectMergeFailureCache.insert(SelectMergeKey);
+    }
   }
   // Scalar, fragment, and mixed explicit occurrences must never fall through
   // to value-global heuristics.  Unlike Address, they carry no complete data-
   // pointer relation for this consumer to own.
-  if (Occurrence.hasExplicitProvenance())
-    if (Occurrence.Model != ConstantProvenanceSummary::ValueModel::Address)
-      return nullptr;
+  if (Occurrence.hasExplicitProvenance() &&
+      Occurrence.Model != ConstantProvenanceSummary::ValueModel::Address) {
+    // A recurrent forwarding PHI can summarize as Mixed even when the
+    // read-only resolver proves one stable data owner.  Keep that exact
+    // certificate; scalar and fragment values remain rejected.
+    if (Occurrence.Model == ConstantProvenanceSummary::ValueModel::Mixed)
+      if (llvm::Value *P = tryResolveReadOnlyDataPtr(
+              AddrVar, /*SizeHint=*/0, FailClosed, Builder))
+        return P;
+    return nullptr;
+  }
   // A flat pointer-valued SELECT must be validated as one unit before creating
   // any globals: every non-null leaf has to be a mapped data address.  This
   // two-pass shape prevents a rejected code/scalar arm from leaving behind a
@@ -472,8 +516,23 @@ llvm::Value *MedLLVMEmitter::tryResolvePointerArg(const MedVar &AddrVar,
       // single data-looking leaf. In a known pointer context that resolver also
       // records the fail-closed diagnostic, while speculative integer arguments
       // simply retain their original ABI value.
-      return tryResolveSelectMergeTable(AddrVar, /*SizeHint=*/0, FailClosed,
-                                        Builder);
+      bool SawAmbiguous = false;
+      if (SelectMergeFailureCacheFor != CurMedFunc) {
+        SelectMergeFailureCacheFor = CurMedFunc;
+        SelectMergeFailureCache.clear();
+      }
+      const auto SelectMergeKey = std::make_tuple(
+          addressProvenanceVarKey(AddrVar), uint16_t(0), FailClosed);
+      if (SelectMergeFailureCache.count(SelectMergeKey))
+        return nullptr;
+      if (llvm::Value *Selected = tryResolveSelectMergeTable(
+              AddrVar, /*SizeHint=*/0, FailClosed, Builder, &SawAmbiguous))
+        return Selected;
+      if (SawAmbiguous)
+        return nullptr;
+      if (!FatalDataPointerResolution && !FatalCodePointerResolution)
+        SelectMergeFailureCache.insert(SelectMergeKey);
+      return nullptr;
     }
 
   // A direct &global (or COPY thereof) first uses exact occurrence ownership.
@@ -482,8 +541,10 @@ llvm::Value *MedLLVMEmitter::tryResolvePointerArg(const MedVar &AddrVar,
   // not acquire pointer meaning here.
   uint64_t OwnedVA = 0;
   uint64_t OwnerVA = InvalidVA;
-  if (resolveMaterializableDataAddress(AddrVar, OwnedVA, &OwnerVA) &&
-      OwnerVA != InvalidVA)
+  const bool HasOwnedData =
+      resolveMaterializableDataAddress(AddrVar, OwnedVA, &OwnerVA) &&
+      OwnerVA != InvalidVA;
+  if (HasOwnedData)
     return tryResolveOwnedGlobalData(OwnedVA, OwnerVA,
                                      /*DataSizeHint=*/0);
   std::optional<uint64_t> ConstAddr =
@@ -498,10 +559,12 @@ llvm::Value *MedLLVMEmitter::tryResolvePointerArg(const MedVar &AddrVar,
   // A computed `&global[index]`: same resolver sequence as a LOAD address, with
   // the writable-data path first since the callee may store through the
   // pointer.
-  if (auto *P = tryResolveWritableData(AddrVar, /*SizeHint=*/0, Builder))
+  if (auto *P = tryResolveWritableData(AddrVar, /*SizeHint=*/0, Builder)) {
     return P;
-  return tryResolveReadOnlyDataPtr(AddrVar, /*SizeHint=*/0, FailClosed,
-                                   Builder);
+  }
+  auto *ReadOnly =
+      tryResolveReadOnlyDataPtr(AddrVar, /*SizeHint=*/0, FailClosed, Builder);
+  return ReadOnly;
 }
 
 } // namespace neverd

--- a/lib/backend/llvm/emit/MedLLVMCall.cpp
+++ b/lib/backend/llvm/emit/MedLLVMCall.cpp
@@ -475,6 +475,14 @@ void MedLLVMEmitter::emitCallOp(const MedOp &Op, llvm::IRBuilder<> &Builder,
                 FT, llvm::GlobalValue::ExternalLinkage, CalleeName, Mod);
             Callee->setCallingConv(llvm::CallingConv::C);
           }
+        } else if (Arity && libc::isVaListConsumer(
+                               stripLeadingUnderscores(CalleeName))) {
+          std::vector<llvm::Type *> ParamTys(
+              static_cast<size_t>(Arity->IntArgs), PtrTy);
+          auto *FT = llvm::FunctionType::get(DefaultRetTy, ParamTys, false);
+          Callee = llvm::Function::Create(
+              FT, llvm::GlobalValue::ExternalLinkage, CalleeName, Mod);
+          Callee->setCallingConv(llvm::CallingConv::C);
         }
       }
 

--- a/lib/backend/llvm/emit/MedLLVMOpEmitter.cpp
+++ b/lib/backend/llvm/emit/MedLLVMOpEmitter.cpp
@@ -778,8 +778,12 @@ void MedLLVMEmitter::emitOp(const MedOp &Op, llvm::IRBuilder<> &Builder,
         bool AllowImplicitZeroBase = false;
         if (const JumpTable *JT = authenticatedJumpTableForLoad(Op))
           AllowImplicitZeroBase = JT->HasBaseAddr && JT->BaseAddr == 0;
+        const MedVar *LoadedRole =
+            Op.Output.Size == getTargetRegInfo(TargetArch).PointerSize
+                ? &Op.Output
+                : nullptr;
         Ptr = tryResolveCodePtrTablePtr(AddrVar, Builder, AllowImplicitZeroBase,
-                                        &Op.Output);
+                                        LoadedRole);
       }
       if (!Ptr)
         // Immutable-data resolver arbitration is shared with pointer

--- a/lib/backend/llvm/emit/MedLLVMReturn.cpp
+++ b/lib/backend/llvm/emit/MedLLVMReturn.cpp
@@ -214,22 +214,42 @@ void MedLLVMEmitter::emitReturnOp(const MedOp &Op, llvm::IRBuilder<> &Builder) {
 
       const MedVar *RetVar = nullptr;
       const MedVar *HiVar = nullptr;
+      bool SawReturnView = false;
+      bool PassedReturn = false;
       for (auto RIt = Blk.Ops.rbegin(); RIt != Blk.Ops.rend(); ++RIt) {
-        if (&*RIt == &Op)
+        if (&*RIt == &Op) {
+          PassedReturn = true;
+          continue;
+        }
+        if (!PassedReturn)
           continue;
         if (RIt->Output.Kind != MedVar::Reg || RIt->Output.Size == 0)
           continue;
 
         if (WantX87 && TRI.isX87StackReg(RIt->Output.RegOff)) {
           // Reverse iteration sees the value at the current x87 top first.
-          if (!RetVar)
+          if (!SawReturnView) {
+            SawReturnView = true;
             RetVar = &RIt->Output;
-        } else if (WantFloat && !WantX87 && RIt->Output.RegOff == FloatRetOff) {
-          if (!RetVar || RIt->Output.Size > RetVar->Size)
+          }
+        } else if (WantFloat && !WantX87 &&
+                   RIt->Output.RegOff == FloatRetOff) {
+          // The newest physical XMM/V register view is authoritative.  Do not
+          // replace it with an older wider view merely to avoid coercion.
+          if (!SawReturnView) {
+            SawReturnView = true;
+            RetVar = &RIt->Output;
+          }
+        } else if (!WantFloat && RIt->Output.RegOff == IntRetOff &&
+                   !SawReturnView) {
+          // A partial integer view is authoritative only when its ABI write
+          // semantics define the requested return width.  If it does not,
+          // stop at that newest view and fail closed instead of using stale
+          // bits from an older full-width definition.
+          SawReturnView = true;
+          if (isAuthoritativeIntegerReturnView(RIt->Output))
             RetVar = &RIt->Output;
         }
-        if (isAuthoritativeIntegerReturnView(RIt->Output) && !RetVar)
-          RetVar = &RIt->Output;
         if (WantWide64 && RIt->Output.RegOff == HiRetOff) {
           // A SUBBYTES that extracts the high PointerSize bytes (e.g. ARM
           // `vmov rLo,rHi,dN` lowers the high register to SUBBYTES(d,4)) is a
@@ -244,7 +264,7 @@ void MedLLVMEmitter::emitReturnOp(const MedOp &Op, llvm::IRBuilder<> &Builder) {
             HiVar = &RIt->Output;
         }
       }
-      if (!RetVar) {
+      if (!RetVar && !SawReturnView) {
         // Pick the *widest* matching phi, not the first.  When a block has
         // both a narrow (EAX) and wide (RAX) phi for the return register,
         // the wide one carries the true 64-bit value (bug #157c).
@@ -351,16 +371,17 @@ void MedLLVMEmitter::emitReturnOp(const MedOp &Op, llvm::IRBuilder<> &Builder) {
         if (BId < 0 || BId >= static_cast<int>(CurMedFunc->Blocks.size()))
           continue;
         auto &Blk = CurMedFunc->Blocks[BId];
-        // Select the *widest* write to the return register, not the last
-        // one in program order.  A narrow sub-register SUBBYTES (e.g.
-        // EAX = SUBBYTES(RAX)) often follows the full-width write but does
-        // not represent the canonical return value (bug #152 extension).
+        // FP/vector return registers are live at the shared epilogue as the
+        // newest physical view.  Keep the legacy widest preference for integer
+        // predecessor recovery, where a narrow SUBBYTES may not define the
+        // canonical full-width value (bug #152 extension).
         const MedVar *RetVar = nullptr;
         for (auto BIt = Blk.Ops.rbegin(); BIt != Blk.Ops.rend(); ++BIt) {
           if (BIt->Output.Kind == MedVar::Reg && BIt->Output.Size > 0 &&
               (WantX87 ? TRI.isX87StackReg(BIt->Output.RegOff)
                        : BIt->Output.RegOff == RetRegOff)) {
-            if (!RetVar || BIt->Output.Size > RetVar->Size)
+            if (!RetVar ||
+                (!WantFloat && BIt->Output.Size > RetVar->Size))
               RetVar = &BIt->Output;
           }
         }

--- a/lib/backend/llvm/emit/MedLLVMReturn.cpp
+++ b/lib/backend/llvm/emit/MedLLVMReturn.cpp
@@ -187,6 +187,20 @@ void MedLLVMEmitter::emitReturnOp(const MedOp &Op, llvm::IRBuilder<> &Builder) {
     bool WantWide64 = !WantFloat && RetTy->isIntegerTy(64) &&
                       TRI.PointerSize == 4 && TRI.IntReturnReg2 != 0;
     uint64_t HiRetOff = TRI.IntReturnReg2;
+    const uint16_t IntegerReturnSize =
+        WantWide64 ? TRI.PointerSize
+                   : RetTy->isIntegerTy()
+                         ? static_cast<uint16_t>(
+                               (RetTy->getIntegerBitWidth() + 7) / 8)
+                         : 0;
+    auto isAuthoritativeIntegerReturnView = [&](const MedVar &V) {
+      if (WantFloat || V.RegOff != IntRetOff || IntegerReturnSize == 0)
+        return false;
+      if (V.Size >= IntegerReturnSize)
+        return true;
+      return TRI.writeZeroExtends(V.RegOff, V.Size) &&
+             TRI.isSubRegOf(V.RegOff, V.Size, IntRetOff, IntegerReturnSize);
+    };
 
     for (auto &Blk : CurMedFunc->Blocks) {
       bool HasThisRet = false;
@@ -214,10 +228,8 @@ void MedLLVMEmitter::emitReturnOp(const MedOp &Op, llvm::IRBuilder<> &Builder) {
           if (!RetVar || RIt->Output.Size > RetVar->Size)
             RetVar = &RIt->Output;
         }
-        if (!WantFloat && RIt->Output.RegOff == IntRetOff) {
-          if (!RetVar || RIt->Output.Size > RetVar->Size)
-            RetVar = &RIt->Output;
-        }
+        if (isAuthoritativeIntegerReturnView(RIt->Output) && !RetVar)
+          RetVar = &RIt->Output;
         if (WantWide64 && RIt->Output.RegOff == HiRetOff) {
           // A SUBBYTES that extracts the high PointerSize bytes (e.g. ARM
           // `vmov rLo,rHi,dN` lowers the high register to SUBBYTES(d,4)) is a
@@ -247,10 +259,8 @@ void MedLLVMEmitter::emitReturnOp(const MedOp &Op, llvm::IRBuilder<> &Builder) {
             if (!RetVar || Phi.Output.Size > RetVar->Size)
               RetVar = &Phi.Output;
           }
-          if (!WantFloat && Phi.Output.RegOff == IntRetOff) {
-            if (!RetVar || Phi.Output.Size > RetVar->Size)
-              RetVar = &Phi.Output;
-          }
+          if (isAuthoritativeIntegerReturnView(Phi.Output) && !RetVar)
+            RetVar = &Phi.Output;
         }
       }
       if (WantWide64 && !HiVar) {

--- a/lib/backend/llvm/emit/MedLLVMSwitch.cpp
+++ b/lib/backend/llvm/emit/MedLLVMSwitch.cpp
@@ -213,8 +213,9 @@ bool MedLLVMEmitter::emitJumpTableSwitch(
       if (Selector.Size != Plan.ResultSize || Selector.isConst() ||
           !ExpectedPreds.count(Pred) || !PlannedPreds.insert(Pred).second)
         return nullptr;
-    if (PlannedPreds != ExpectedPreds)
+    if (PlannedPreds != ExpectedPreds) {
       return nullptr;
+    }
 
     auto *Ty = sizeToType(Plan.ResultSize);
     auto &Entry = CurFunc->getEntryBlock();
@@ -313,8 +314,9 @@ bool MedLLVMEmitter::emitJumpTableSwitch(
       const bool HasEdgeMergedPlan =
           PlanIt != CurMedFunc->SwitchSelectorPlans.end() &&
           PlanIt->second.PlanKind == MedSwitchSelectorPlan::Kind::EdgeMerged;
-      if (!IndexVar && !HasEdgeMergedPlan)
+      if (!IndexVar && !HasEdgeMergedPlan) {
         return false;
+      }
     }
     // A two-level (index-byte) table composes its per-case targets from
     // `jmptab[idxtab[switchvar]]`; the switch condition is the *real* switch
@@ -384,8 +386,9 @@ bool MedLLVMEmitter::emitJumpTableSwitch(
     // index) is recovered after target validation via
     // synthesizeSharedDispatchIndex; only bail here when there is no such
     // fallback (≤1 predecessor).
-    if (!IndexVar && Blk.Preds.size() < 2)
+    if (!IndexVar && Blk.Preds.size() < 2) {
       return false;
+    }
   }
 
   // Present the switch on the *source* variable and labels rather than the
@@ -438,15 +441,18 @@ bool MedLLVMEmitter::emitJumpTableSwitch(
   CaseBlocks.reserve(JT->Targets.size());
   for (va_t T : JT->Targets) {
     int BId = blockForTarget(T);
-    if (BId < 0)
+    if (BId < 0) {
       return false;
+    }
     auto BIt = BBMap.find(BId);
-    if (BIt == BBMap.end())
+    if (BIt == BBMap.end()) {
       return false;
+    }
     CaseBlocks.push_back(BIt->second);
   }
-  if (CaseBlocks.empty())
+  if (CaseBlocks.empty()) {
     return false;
+  }
 
   llvm::Value *Index =
       JT->TwoTableSelect ? synthesizeTwoTableSelector(*JT, Builder)
@@ -454,8 +460,9 @@ bool MedLLVMEmitter::emitJumpTableSwitch(
       : !JT->SelectorUseRefs.empty()
           ? edgeMergedIndexFromSelectorPlan()
           : synthesizeSharedDispatchIndex(Blk, BrOp, *JT, Builder);
-  if (!Index || !Index->getType()->isIntegerTy())
+  if (!Index || !Index->getType()->isIntegerTy()) {
     return false;
+  }
   auto *IdxTy = llvm::cast<llvm::IntegerType>(Index->getType());
 
   // The table address calculation wraps at the target's pointer width.  Some
@@ -473,8 +480,9 @@ bool MedLLVMEmitter::emitJumpTableSwitch(
 
   const unsigned IdxBits = IdxTy->getBitWidth();
   auto CaseBits = uniqueSwitchCaseBitPatterns(Labels, LabelDelta, IdxBits);
-  if (!CaseBits)
+  if (!CaseBits) {
     return false;
+  }
 
   // A recovered table describes only the selectors whose target mapping was
   // proved.  Routing any gap, truncated composite domain, or stale/out-of-

--- a/lib/backend/llvm/resolve/MedLLVMAddrResolve.cpp
+++ b/lib/backend/llvm/resolve/MedLLVMAddrResolve.cpp
@@ -762,6 +762,9 @@ void MedLLVMEmitter::invalidateFeasibleEdgeDependentCaches() const {
   FrameDerivedCache.clear();
   FrameAddressCacheFor = nullptr;
   FrameAddressCache.clear();
+  FrameReloadCacheFor = nullptr;
+  FrameReloadCache.clear();
+  ++FrameReloadCacheGeneration;
 }
 
 void MedLLVMEmitter::ensureFeasibleEdgeCache() const {
@@ -1403,9 +1406,9 @@ bool MedLLVMEmitter::valueIsStableAddressOffsetImpl(
   // condition or shift/mask control does not anchor the selected scalar.
   // Exact frame reload sources are followed so an SSA PHI whose backedge is
   // carried through a spill slot remains one scalar SCC.
-  std::function<bool(const MedVar &, const Key &, int, std::set<Key>)>
+  std::function<bool(const MedVar &, const Key &, int, std::set<Key> &)>
       scalarValueReaches = [&](const MedVar &Start, const Key &Target,
-                               int Depth, std::set<Key> Seen) -> bool {
+                               int Depth, std::set<Key> &Seen) -> bool {
     if (Depth > 128 || Start.isConst())
       return false;
     const Key StartKey = keyOf(Start);
@@ -1413,6 +1416,11 @@ bool MedLLVMEmitter::valueIsStableAddressOffsetImpl(
       return true;
     if (!Seen.insert(StartKey).second)
       return false;
+    struct SeenScope {
+      std::set<Key> &Values;
+      Key Value;
+      ~SeenScope() { Values.erase(Value); }
+    } Scope{Seen, StartKey};
     if (const PhiNode *Phi = lookupPhi(Start)) {
       for (const auto &[Pred, Arg] : Phi->Args)
         if (classifyPhiIncomingEdge(*Phi, Pred) ==
@@ -1425,7 +1433,7 @@ bool MedLLVMEmitter::valueIsStableAddressOffsetImpl(
     if (!Def || Def->NumInputs < 1)
       return false;
     if (auto Forwarded = pointerPreservingInput(*Def))
-      return scalarValueReaches(*Forwarded, Target, Depth + 1, std::move(Seen));
+      return scalarValueReaches(*Forwarded, Target, Depth + 1, Seen);
     if (Def->Opcode == NdOp::LOAD) {
       std::vector<MedVar> Sources;
       if (!collectFrameReloadSources(*Def, Sources) || Sources.empty())
@@ -1438,12 +1446,12 @@ bool MedLLVMEmitter::valueIsStableAddressOffsetImpl(
     if (Def->Opcode == NdOp::SELECT && Def->NumInputs >= 3)
       return scalarValueReaches(Def->Inputs[1], Target, Depth + 1, Seen) ||
              scalarValueReaches(Def->Inputs[2], Target, Depth + 1,
-                                std::move(Seen));
+                                Seen);
     if (Def->Opcode == NdOp::INT_OR) {
       MedVar Cond, ArmT, ArmF;
       if (isMaskedSelectOr(*Def, Cond, ArmT, ArmF))
         return scalarValueReaches(ArmT, Target, Depth + 1, Seen) ||
-               scalarValueReaches(ArmF, Target, Depth + 1, std::move(Seen));
+               scalarValueReaches(ArmF, Target, Depth + 1, Seen);
     }
     switch (Def->Opcode) {
     case NdOp::COPY:
@@ -1477,9 +1485,11 @@ bool MedLLVMEmitter::valueIsStableAddressOffsetImpl(
   std::function<bool(const MedVar &, const std::set<Key> &)>
       reachesAnchoredPhi =
           [&](const MedVar &Start, const std::set<Key> &AnchoredPhis) {
-            for (const Key &Anchor : AnchoredPhis)
-              if (scalarValueReaches(Start, Anchor, 0, {}))
+            for (const Key &Anchor : AnchoredPhis) {
+              std::set<Key> Seen;
+              if (scalarValueReaches(Start, Anchor, 0, Seen))
                 return true;
+            }
             return false;
           };
 
@@ -1583,7 +1593,8 @@ bool MedLLVMEmitter::valueIsStableAddressOffsetImpl(
     std::set<Key> Seen;
     int Budget = 8192;
     auto reachesRoot = [&](const MedVar &Value) {
-      return scalarValueReaches(Value, RootKey, 0, {});
+      std::set<Key> Path;
+      return scalarValueReaches(Value, RootKey, 0, Path);
     };
     auto inspectValueArms = [&](const std::vector<MedVar> &Arms,
                                 bool &FoundInitializer) {
@@ -1798,7 +1809,10 @@ bool MedLLVMEmitter::valueIsStableAddressOffsetImpl(
         SawPotential = true;
         Arms.push_back(
             {NestedPred, NestedArg,
-             scalarValueReaches(NestedArg, keyOf(Start), 0, {}) ||
+             ([&] {
+               std::set<Key> Path;
+               return scalarValueReaches(NestedArg, keyOf(Start), 0, Path);
+             }()) ||
                  phiIncomingClosesFeasibleControlCycle(*Nested, NestedPred)});
       }
       if (!SawPotential)

--- a/lib/backend/llvm/resolve/MedLLVMCodePtrResolve.cpp
+++ b/lib/backend/llvm/resolve/MedLLVMCodePtrResolve.cpp
@@ -915,8 +915,9 @@ llvm::Value *MedLLVMEmitter::tryResolveCodePtrTablePtr(
   // a single constant base.  When every base-like constant in the address lands
   // in ONE pointer-table segment, the whole address provably indexes that
   // segment, so redirect by the address's own value: GEP(@seg, addr - segVA).
-  if (auto SelSegOpt =
-          ptrTableUniqueSegment(AddrVar, /*IncludeSymbolizedEvidence=*/true)) {
+  auto SelSegOpt =
+      ptrTableUniqueSegment(AddrVar, /*IncludeSymbolizedEvidence=*/true);
+  if (SelSegOpt) {
     const uint64_t SelSeg = *SelSegOpt;
     // Recovered switch metadata deliberately keeps ordinary, dead residual
     // jump-table loads out of generic constant symbolization.  A residual
@@ -1947,6 +1948,14 @@ MedLLVMEmitter::tryResolveIndirectCallTarget(const MedVar &V,
     const PointerTableLoadRoleSummary SlotRoles =
         classifyPointerTableLoadRoles(V);
     if (SlotRoles.Recognized) {
+      // A code-bearing mixed run may still have adjacent unknown/data slots.
+      // Preserve only an unadjusted value loaded through an architectural
+      // register address; getVar retains its relocation-safe runtime value.
+      if (SlotRoles.SawCode && SlotRoles.ValueAdjustment == 0 &&
+          SlotRoles.Load && SlotRoles.Load->NumInputs >= 1 &&
+          SlotRoles.Load->Inputs[0].Kind == MedVar::Reg)
+        if (llvm::Value *Target = getVar(V, Builder))
+          return Target;
       // The LOAD emitter has already routed this address through the mixed
       // relocation mirror. Reuse that relocation-safe runtime value only when
       // every reachable slot is a code/import field and no post-load pointer

--- a/lib/ir/low/CFGBuilder.cpp
+++ b/lib/ir/low/CFGBuilder.cpp
@@ -530,9 +530,11 @@ LowFunc CFGBuilder::build(const BinaryImage &Img, Decoder &Dec, va_t EntryAddr,
       if (Insns.count(Addr))
         Func.UnsafeIndirectBranchAddresses.insert(Addr);
   if (PreservePotentialJumpTableBranches)
-    for (va_t Addr : PotentialJumpTableBranches)
-      if (Insns.count(Addr))
+    for (va_t Addr : PotentialJumpTableBranches) {
+      auto It = Insns.find(Addr);
+      if (It != Insns.end() && It->second.JumpTableTargets.empty())
         Func.UnsafeIndirectBranchAddresses.insert(Addr);
+    }
   for (va_t Addr : LostValidatedJumpTableBranches)
     if (Insns.count(Addr))
       Func.UnsafeIndirectBranchAddresses.insert(Addr);
@@ -1525,10 +1527,13 @@ void CFGBuilder::multiStageResolve(const BinaryImage &Img, Decoder &Dec,
         EverPublishedJumpTableBranches.insert(UA);
 
       for (va_t T : Targets) {
-        if (!ExploredAddrs.count(T)) {
-          BlockStarts.insert(T);
+        // A target may already be decoded when proof metadata is
+        // revalidated.  It still needs a block boundary before Med/LLVM
+        // lowers the indirect branch to a finite switch.
+        if (BlockStarts.insert(T).second)
+          MadeProgress = true;
+        if (!ExploredAddrs.count(T))
           explore(Img, Dec, T);
-        }
       }
     }
 

--- a/lib/ir/low/FuncDetector.cpp
+++ b/lib/ir/low/FuncDetector.cpp
@@ -235,11 +235,6 @@ FuncDetector::detect(const BinaryImage &Img, Decoder &Dec) {
     const size_t N = Results.size();
     std::vector<char> Keep(N, 0);
     std::vector<size_t> NeedVerify;
-    std::set<va_t> ExplicitFunctionStarts;
-    for (const auto &Sym : Img.Symbols)
-      if (Sym.IsFunc)
-        ExplicitFunctionStarts.insert(
-            normalizeCodeAddress(Sym.Addr, Img.Arch, Img.Mode));
     for (size_t I = 0; I < N; ++I) {
       va_t Addr = Results[I].first;
       if (Trusted.count(Addr))

--- a/lib/ir/low/FuncDetector.cpp
+++ b/lib/ir/low/FuncDetector.cpp
@@ -227,10 +227,19 @@ FuncDetector::detect(const BinaryImage &Img, Decoder &Dec) {
     // cover unsymbolized leaf callees on every supported architecture.
     // Untyped COFF exports are always verified because they can be either
     // callable aliases or data.  Only the remaining candidates need the
-    // expensive trial decode.
+    // The trial decode dominates only when the scan produced many untrusted
+    // candidates; each check is independent and reads only the immutable image,
+    // so spread that subset across worker threads with per-thread decoders. A
+    // symbol-rich binary (almost everything trusted) leaves NeedVerify small
+    // and stays single-threaded, avoiding pointless thread-spawn overhead.
     const size_t N = Results.size();
     std::vector<char> Keep(N, 0);
     std::vector<size_t> NeedVerify;
+    std::set<va_t> ExplicitFunctionStarts;
+    for (const auto &Sym : Img.Symbols)
+      if (Sym.IsFunc)
+        ExplicitFunctionStarts.insert(
+            normalizeCodeAddress(Sym.Addr, Img.Arch, Img.Mode));
     for (size_t I = 0; I < N; ++I) {
       va_t Addr = Results[I].first;
       if (Trusted.count(Addr))

--- a/lib/ir/low/jumptable/JumpTableResolver.cpp
+++ b/lib/ir/low/jumptable/JumpTableResolver.cpp
@@ -181,6 +181,13 @@ std::vector<va_t> CFGBuilder::resolveJumpTable(const BinaryImage &Img,
                                                const InsnRecord &Rec) {
   const std::set<va_t> DecodedTableAnchors =
       currentRelocatedInstructionTableAnchors(Img);
+  // Preserve the immediately prior proof only for fixed-point revalidation.
+  // Target blocks may be added after publication, but the certified table
+  // expression and guard occur before the indirect branch and remain unchanged.
+  std::optional<JumpTableInfo> PriorInfo;
+  if (auto It = ResolvedTableInfo.find(Rec.Addr);
+      It != ResolvedTableInfo.end())
+    PriorInfo = It->second;
   // A revalidation must never leave metadata from the previously published
   // target set behind when the new proof fails or shrinks.
   ResolvedTableInfo.erase(Rec.Addr);
@@ -590,8 +597,9 @@ std::vector<va_t> CFGBuilder::resolveJumpTable(const BinaryImage &Img,
   // at the same addresses, or emulator address co-occurrence, is not evidence.
   const bool TargetRole = branchTargetDependsOnTableLoad(Rec, Info);
   const bool AddressRole = tableLoadAddressesMatchRole(Info);
-  if (!TargetRole || !AddressRole)
+  if (!TargetRole || !AddressRole) {
     return {};
+  }
   Info.MutatedUnsafe |= ModuleMutationUnsafe;
 
   // A runtime-selected dispatch over two non-adjacent code-pointer tables
@@ -651,7 +659,30 @@ std::vector<va_t> CFGBuilder::resolveJumpTable(const BinaryImage &Img,
   // table may already carry an independently authenticated index domain; a
   // relocation run by itself is only physical storage capacity and never
   // skips this search.
+  const bool ReusePriorGuardProof =
+      PriorInfo && !Rec.JumpTableTargets.empty() &&
+      PriorInfo->AuthenticatedGuardBound >= limits::kMinJumpTableEntries &&
+      PriorInfo->HasBaseAddr == Info.HasBaseAddr &&
+      PriorInfo->BaseAddr == Info.BaseAddr &&
+      PriorInfo->EntrySize == Info.EntrySize &&
+      PriorInfo->EntryStride == Info.EntryStride &&
+      PriorInfo->IsRelative == Info.IsRelative &&
+      PriorInfo->IsSigned == Info.IsSigned &&
+      PriorInfo->HasTargetBase == Info.HasTargetBase &&
+      PriorInfo->TargetBase == Info.TargetBase &&
+      PriorInfo->EntryScale == Info.EntryScale &&
+      PriorInfo->TableLoadAddr == Info.TableLoadAddr &&
+      PriorInfo->TableLoadSeq == Info.TableLoadSeq &&
+      PriorInfo->IndexValueAtUse == Info.IndexValueAtUse &&
+      PriorInfo->IndexUseAddr == Info.IndexUseAddr &&
+      PriorInfo->IndexUseSeq == Info.IndexUseSeq;
   bool GuardFound = Info.IndexDomainAuthenticated;
+  if (!GuardFound && ReusePriorGuardProof) {
+    Info.MaxEntries = PriorInfo->AuthenticatedGuardBound;
+    Info.IndexDomainAuthenticated = true;
+    Info.AuthenticatedGuardBound = PriorInfo->AuthenticatedGuardBound;
+    GuardFound = true;
+  }
   if (!GuardFound) {
     GuardFound = inferBoundsFromPreciseGuards(Rec, Info);
     if (GuardFound) {
@@ -750,7 +781,8 @@ std::vector<va_t> CFGBuilder::resolveJumpTable(const BinaryImage &Img,
   const uint32_t MaskBound = inferBoundsFromMask(
       Rec, Info, /*AllowNonContiguous=*/true, &IncompleteMaskDomain,
       &UsedNonContiguousMask, &MaskCoordinates);
-  if (!Info.TwoTableSelect && !Info.TwoLevelIndex && MaskBound > 0) {
+  if (!IncompleteMaskDomain && !Info.TwoTableSelect &&
+      !Info.TwoLevelIndex && MaskBound > 0) {
     Info.AuthenticatedMaskCoordinates = MaskCoordinates;
     // The next-anchor cap is a runtime-domain heuristic: another reachable
     // consumer may name an interior relocation without ending the physical
@@ -913,16 +945,18 @@ std::vector<va_t> CFGBuilder::resolveJumpTable(const BinaryImage &Img,
   // the quotient/flag calculation.  Final-root revalidation below replays that
   // independent witness after ownership has been narrowed.
   if (IncompleteMaskDomain && Info.AuthenticatedGuardBound == 0 &&
-      Info.AuthenticatedModuloBound == 0)
+      Info.AuthenticatedModuloBound == 0) {
     return {};
+  }
   // A sampled/non-prefix guard must not be rescued by a relocation run: the
   // run proves readable table storage, not which selector values can reach
   // it.  An independently authenticated exact mask domain is sufficient
   // because it bounds the actual address coordinate regardless of the guard;
   // the legacy modulo recognizer is intentionally not a rescue here until it
   // is occurrence/CFG authenticated in the same way.
-  if (Info.IncompleteGuardDomain && !Info.IndexDomainAuthenticated)
+  if (Info.IncompleteGuardDomain && !Info.IndexDomainAuthenticated) {
     return {};
+  }
 
   if (Info.MaxEntries == 0 || Info.MaxEntries > limits::kMaxJumpTableEntries)
     Info.MaxEntries = 0;
@@ -937,8 +971,9 @@ std::vector<va_t> CFGBuilder::resolveJumpTable(const BinaryImage &Img,
   // index bound.  A single immutable pointer is a separate direct-branch
   // problem and is intentionally not published as a jump table here.
   if (!Info.IndexDomainAuthenticated ||
-      Info.MaxEntries < limits::kMinJumpTableEntries)
+      Info.MaxEntries < limits::kMinJumpTableEntries) {
     return {};
+  }
 
   // Capacity constrains an authenticated domain; it never supplies one.  A
   // domain that exceeds known storage cannot be repaired by taking min(),
@@ -1007,8 +1042,10 @@ std::vector<va_t> CFGBuilder::resolveJumpTable(const BinaryImage &Img,
       Check.MaxEntries = 0;
       Check.IndexDomainAuthenticated = false;
       Check.IncompleteGuardDomain = false;
-      if (!inferBoundsFromPreciseGuards(Rec, Check) ||
-          Check.MaxEntries != Info.AuthenticatedGuardBound)
+      const bool GuardReplay =
+          ReusePriorGuardProof || inferBoundsFromPreciseGuards(Rec, Check);
+      if (!ReusePriorGuardProof &&
+          (!GuardReplay || Check.MaxEntries != Info.AuthenticatedGuardBound))
         return false;
       Revalidated = true;
     }
@@ -1039,7 +1076,8 @@ std::vector<va_t> CFGBuilder::resolveJumpTable(const BinaryImage &Img,
     // replayable full-domain witness.
     return Revalidated;
   };
-  if (!RevalidateIndexDomain())
+  const bool RevalidatedIndexDomain = RevalidateIndexDomain();
+  if (!RevalidatedIndexDomain)
     return {};
   if (!branchTargetDependsOnTableLoad(Rec, Info))
     return {};
@@ -1568,7 +1606,6 @@ std::vector<va_t> CFGBuilder::resolveJumpTable(const BinaryImage &Img,
                  << (Info.IsRelative ? " (relative" : " (absolute")
                  << (Info.IsSigned ? ", signed)" : ")") << "\n";
   });
-
   return Targets;
 }
 

--- a/lib/ir/low/jumptable/JumpTableResolverARM.cpp
+++ b/lib/ir/low/jumptable/JumpTableResolverARM.cpp
@@ -288,10 +288,12 @@ bool CFGBuilder::tryAArch64CompactTable(const BinaryImage &Img,
     NdVar Value;
     va_t UseAddr = InvalidVA;
     int UseSeq = -1;
+    std::vector<JumpTableValueOccurrence> Alternatives;
   };
   IndexCandidate CandA, CandB, IndexCandidateAtLoad;
   uint64_t IndexReg = InvalidVA;
   int TableLoadIdx = -1;
+  int AddressAddIdx = -1;
   {
     NdVar V = Ops[ShiftIdx].Inputs[0];
     int CurFrom = ShiftIdx - 1;
@@ -318,6 +320,7 @@ bool CFGBuilder::tryAArch64CompactTable(const BinaryImage &Img,
         const NdVar &AddrV = (O.NumInputs >= 2) ? O.Inputs[1] : O.Inputs[0];
         int A = reachingDefIdx(Ops, D - 1, AddrV);
         if (A >= 0 && Ops[A].Opcode == NdOp::INT_ADD && Ops[A].NumInputs >= 2) {
+          AddressAddIdx = A;
           // Each address operand is either a bare register (the table base, or
           // the index of a byte table `ldrb [base,idx]`) or a scaled index (the
           // index of a halfword table `ldrh [base,idx,lsl #1]`, whose
@@ -327,17 +330,14 @@ bool CFGBuilder::tryAArch64CompactTable(const BinaryImage &Img,
           // scaled-index trace when the operand is not a plain register.
           auto candReg = [&](const NdVar &In) -> IndexCandidate {
             IndexCandidate Candidate;
-            uint64_t R = traceToRegister(Ops, A - 1, In);
-            if (R != InvalidVA) {
-              Candidate.Reg = R;
-              Candidate.Value = In;
-              Candidate.UseAddr = Ops[A].Addr;
-              Candidate.UseSeq = Ops[A].Seq;
-              return Candidate;
-            }
-            Candidate.Reg =
-                scaledIndexReg(Ops, A - 1, In, &Candidate.Value,
-                               &Candidate.UseAddr, &Candidate.UseSeq);
+            Candidate.Value = In;
+            Candidate.UseAddr = Ops[A].Addr;
+            Candidate.UseSeq = Ops[A].Seq;
+            Candidate.Reg = traceToRegister(Ops, A - 1, In);
+            if (Candidate.Reg == InvalidVA)
+              Candidate.Reg =
+                  scaledIndexReg(Ops, A - 1, In, &Candidate.Value,
+                                 &Candidate.UseAddr, &Candidate.UseSeq);
             return Candidate;
           };
           CandA = candReg(Ops[A].Inputs[0]);
@@ -352,6 +352,64 @@ bool CFGBuilder::tryAArch64CompactTable(const BinaryImage &Img,
 
   // Whichever address operand folds to a non-empty data segment is the table
   // base; the other is the switch index register.
+  auto normalizeLogicalLane = [&](IndexCandidate &Candidate) {
+    if (Candidate.Reg == InvalidVA || Candidate.Value.Size == 0 ||
+        Candidate.UseAddr == InvalidVA || Candidate.UseSeq < 0)
+      return;
+    std::vector<JumpTableValueOccurrence> Alternatives;
+    for (const LowOp &Def : Ops)
+      if (Def.Opcode == NdOp::INT_ZEXT && Def.NumInputs >= 1 &&
+          Def.Output == Candidate.Value &&
+          Def.Inputs[0].Size != 0 &&
+          Def.Inputs[0].Size < Def.Output.Size &&
+          (Def.Inputs[0].isReg() || Def.Inputs[0].isTemp()) &&
+          (Def.Addr < Candidate.UseAddr ||
+           (Def.Addr == Candidate.UseAddr &&
+            Def.Seq < Candidate.UseSeq)))
+        Alternatives.push_back({Def.Inputs[0], Def.Addr, Def.Seq, false});
+    if (Alternatives.empty())
+      return;
+    auto matches = [&](const std::vector<JumpTableValueOccurrence> &Values) {
+      const std::vector<bool> Result = tableValuesMatchAtUses({
+          {Candidate.Value, Candidate.UseAddr, Candidate.UseSeq, Values,
+           /*AllowZeroExtension=*/true, /*AllowSignExtension=*/false}});
+      return !Result.empty() && Result.front();
+    };
+    if (!matches(Alternatives))
+      return;
+    // Remove alternatives in batches; each candidate set still needs a full
+    // occurrence proof before deletion.
+    std::sort(Alternatives.begin(), Alternatives.end(),
+              [](const auto &Left, const auto &Right) {
+                return std::tie(Left.Addr, Left.Seq) >
+                       std::tie(Right.Addr, Right.Seq);
+              });
+    for (size_t Chunk = Alternatives.size() / 2; Chunk > 0;
+         Chunk = Chunk == 1 ? 0 : (Chunk + 1) / 2) {
+      for (size_t I = 0; I + Chunk < Alternatives.size();) {
+        std::vector<JumpTableValueOccurrence> Trial = Alternatives;
+        Trial.erase(Trial.begin() + static_cast<ptrdiff_t>(I),
+                     Trial.begin() + static_cast<ptrdiff_t>(I + Chunk));
+        if (!Trial.empty() && matches(Trial))
+          Alternatives = std::move(Trial);
+        else
+          ++I;
+      }
+    }
+    const uint16_t Width = Alternatives.front().Value.Size;
+    if (Width == 0 ||
+        std::any_of(Alternatives.begin(), Alternatives.end(),
+                    [&](const auto &Occurrence) {
+                      return Occurrence.Value.Size != Width;
+                    }))
+      return;
+    Candidate.Alternatives = std::move(Alternatives);
+    Candidate.Value = Candidate.Alternatives.front().Value;
+    Candidate.UseAddr = Candidate.Alternatives.front().Addr;
+    Candidate.UseSeq = Candidate.Alternatives.front().Seq;
+    if (Candidate.Value.isReg())
+      Candidate.Reg = Candidate.Value.Offset;
+  };
   std::optional<uint64_t> TableBase;
   for (int Pick = 0; Pick < 2; ++Pick) {
     uint64_t BaseCand = Pick == 0 ? CandA.Reg : CandB.Reg;
@@ -368,11 +426,50 @@ bool CFGBuilder::tryAArch64CompactTable(const BinaryImage &Img,
       break;
     }
   }
-  if (!TableBase)
+  if (!TableBase) {
     return false;
+  }
   const auto *TSeg = Img.getSegmentFor(*TableBase);
   if (!TSeg || TSeg->Data.empty())
     return false;
+  // Compact tables use one scale for the table address and another for the
+  // loaded target entry.  Publish the unscaled selector occurrence, not the
+  // byte offset used by the LOAD address; otherwise MedIR treats the address
+  // arithmetic as the switch selector and the exact-use plan cannot recover
+  // the logical index.
+  if (LoadWidth > 1 && AddressAddIdx >= 0) {
+    int ScaleDef = reachingDefIdx(Ops, AddressAddIdx - 1,
+                                  IndexCandidateAtLoad.Value);
+    if (ScaleDef >= 0) {
+      const LowOp &Scale = Ops[ScaleDef];
+      int InputNo = -1;
+      for (int I = 0; I < Scale.NumInputs; ++I)
+        if (!Scale.Inputs[I].isConst() &&
+            ((Scale.Opcode == NdOp::INT_LEFT && I == 0 &&
+              Scale.NumInputs >= 2 && Scale.Inputs[1].isConst() &&
+              Scale.Inputs[1].Offset < 64 &&
+              (uint64_t{1} << Scale.Inputs[1].Offset) == LoadWidth) ||
+             (Scale.Opcode == NdOp::INT_MULT && I == 0 &&
+              Scale.NumInputs >= 2 && Scale.Inputs[1].isConst() &&
+              Scale.Inputs[1].Offset == LoadWidth))) {
+          if (InputNo >= 0) {
+            InputNo = -1;
+            break;
+          }
+          InputNo = I;
+        }
+      if (InputNo >= 0) {
+        IndexCandidateAtLoad.Value = Scale.Inputs[InputNo];
+        IndexCandidateAtLoad.UseAddr = Scale.Addr;
+        IndexCandidateAtLoad.UseSeq = Scale.Seq;
+        IndexCandidateAtLoad.Reg =
+            traceToRegister(Ops, ScaleDef - 1, Scale.Inputs[InputNo]);
+        IndexCandidateAtLoad.Alternatives.clear();
+      }
+    }
+  }
+  normalizeLogicalLane(IndexCandidateAtLoad);
+  IndexReg = IndexCandidateAtLoad.Reg;
 
   // Resolve the anchor operand to a code address (an `adr` lifts to a COPY of
   // the absolute target constant).
@@ -425,6 +522,7 @@ bool CFGBuilder::tryAArch64CompactTable(const BinaryImage &Img,
   Info.IndexValueAtUse = IndexCandidateAtLoad.Value;
   Info.IndexUseAddr = IndexCandidateAtLoad.UseAddr;
   Info.IndexUseSeq = IndexCandidateAtLoad.UseSeq;
+  Info.IndexValueAlternatives = IndexCandidateAtLoad.Alternatives;
   if (TableLoadIdx >= 0) {
     Info.TableLoadAddr = Ops[TableLoadIdx].Addr;
     Info.TableLoadSeq = Ops[TableLoadIdx].Seq;

--- a/lib/ir/low/jumptable/JumpTableResolverGuardAlias.cpp
+++ b/lib/ir/low/jumptable/JumpTableResolverGuardAlias.cpp
@@ -620,7 +620,7 @@ bool CFGBuilder::inferBoundsFromPreciseGuards(const InsnRecord &Rec,
 
   std::vector<va_t> GuardBranchAddrs;
   for (const auto &[BranchAddr, BranchRec] : Insns) {
-    if (BranchAddr == Rec.Addr || !BranchRec.IsCond || !BranchRec.IsBranch)
+    if (!BranchRec.IsCond || !BranchRec.IsBranch)
       continue;
     GuardBranchAddrs.push_back(BranchAddr);
   }

--- a/lib/ir/low/jumptable/JumpTableResolverSlice.cpp
+++ b/lib/ir/low/jumptable/JumpTableResolverSlice.cpp
@@ -3765,7 +3765,9 @@ bool CFGBuilder::tableLoadAddressesMatchRole(JumpTableInfo &Info) const {
           std::optional<size_t> IndexQuery;
           if (!LocallyAuthenticatedIndex)
             IndexQuery = pushQuery(AddressQueries, DynamicValue, Add,
-                                   State.DynamicAlternatives);
+                                   State.DynamicAlternatives,
+                                   Role.AllowZeroExtension,
+                                   Role.AllowSignExtension);
           if (!BaseQuery || (!LocallyAuthenticatedIndex && !IndexQuery))
             return false;
           ProofQueries.push_back(*BaseQuery);
@@ -3951,11 +3953,12 @@ CFGBuilder::tableLoadConditionValues(llvm::ArrayRef<va_t> BranchAddrs,
     WorkBudget -= Amount;
     return true;
   };
-
+  // Snapshot bookkeeping is per instruction; op-level proof work is charged by
+  // the CFG walks and value matcher below.
   std::vector<ResolverInsnSnapshot> Snapshot;
   Snapshot.reserve(Insns.size());
   for (const auto &[Addr, Rec] : Insns) {
-    if (!consumeWork(1 + Rec.Ops.size()))
+    if (!consumeWork())
       return Results;
     ResolverInsnSnapshot S;
     S.Addr = Addr;
@@ -4010,7 +4013,6 @@ CFGBuilder::tableLoadConditionValues(llvm::ArrayRef<va_t> BranchAddrs,
     }
     return false;
   };
-
   const std::vector<int> &Roots = Graph.RootBlocks;
   auto blockFor = [&](va_t Addr) -> int {
     auto It = Graph.InsnToBlock.find(Addr);

--- a/lib/ir/med/abi/MedABIPass.cpp
+++ b/lib/ir/med/abi/MedABIPass.cpp
@@ -17,29 +17,188 @@
 #include "neverd/ir/TargetRegInfo.h"
 #include "neverd/libc/LibCNames.h"
 #include "neverd/object/SectionNames.h"
+#include "../../../safety/StackSlotFlow.h"
 
 #include "llvm/ADT/StringExtras.h"
 
 #include <algorithm>
+#include <functional>
 #include <map>
 #include <optional>
 #include <set>
 #include <string>
 #include <tuple>
 #include <vector>
-
 namespace neverd {
+
+namespace {
+using EntrySpKey = std::tuple<uint8_t, int, int, uint64_t, uint16_t>;
+
+EntrySpKey entrySpKey(const MedVar &V) {
+  return {static_cast<uint8_t>(V.Kind), V.Id, V.SSAVer,
+          V.Kind == MedVar::Reg ? V.RegOff : 0, V.Size};
+}
+
+std::optional<int64_t> exactEntrySpDelta(const MedFunc &Func, Arch TheArch,
+                                           const MedVar &Root) {
+  const auto &TRI = getTargetRegInfo(TheArch);
+  std::map<EntrySpKey, const MedOp *> Definitions;
+  std::set<EntrySpKey> Ambiguous;
+  std::map<EntrySpKey, const PhiNode *> Phis;
+  std::set<EntrySpKey> AmbiguousPhis;
+  for (const auto &Block : Func.Blocks) {
+    for (const auto &Op : Block.Ops) {
+      if (Op.Output.Kind != MedVar::Reg && Op.Output.Kind != MedVar::Temp)
+        continue;
+      const auto Key = entrySpKey(Op.Output);
+      auto [It, Inserted] = Definitions.emplace(Key, &Op);
+      if (!Inserted && It->second != &Op)
+        Ambiguous.insert(Key);
+    }
+    for (const auto &Phi : Block.Phis) {
+      const auto Key = entrySpKey(Phi.Output);
+      auto [It, Inserted] = Phis.emplace(Key, &Phi);
+      if (!Inserted && It->second != &Phi)
+        AmbiguousPhis.insert(Key);
+    }
+  }
+
+  std::set<EntrySpKey> Active;
+  std::function<std::optional<int64_t>(const MedVar &)> Eval =
+      [&](const MedVar &V) -> std::optional<int64_t> {
+    if (V.isConst()) {
+      if (V.Provenance != ConstantAddressProvenance::Unknown &&
+          V.Provenance != ConstantAddressProvenance::Scalar)
+        return std::nullopt;
+      return static_cast<int64_t>(V.ConstVal);
+    }
+    if (V.Kind != MedVar::Reg && V.Kind != MedVar::Temp)
+      return std::nullopt;
+    if (V.Kind == MedVar::Reg && V.RegOff == TRI.StackPointer &&
+        V.SSAVer == 0)
+      return int64_t{0};
+
+    const auto Key = entrySpKey(V);
+    if (Ambiguous.count(Key) || AmbiguousPhis.count(Key) ||
+        !Active.insert(Key).second)
+      return std::nullopt;
+    auto It = Definitions.find(Key);
+    if (It == Definitions.end()) {
+      Active.erase(Key);
+      return std::nullopt;
+    }
+    const MedOp &Op = *It->second;
+    std::optional<int64_t> Result;
+    switch (Op.Opcode) {
+    case NdOp::COPY:
+    case NdOp::INT_ZEXT:
+    case NdOp::INT_SEXT:
+      if (Op.NumInputs >= 1)
+        Result = Eval(Op.Inputs[0]);
+      break;
+    case NdOp::SUBBYTES:
+      if (Op.NumInputs >= 2 && Op.Inputs[1].isConst() &&
+          Op.Inputs[1].ConstVal == 0)
+        Result = Eval(Op.Inputs[0]);
+      break;
+    case NdOp::INT_ADD:
+    case NdOp::INT_SUB:
+      if (Op.NumInputs >= 2) {
+        const MedVar &A = Op.Inputs[0];
+        const MedVar &B = Op.Inputs[1];
+        if (A.isConst() && !B.isConst()) {
+          auto Base = Eval(B);
+          if (Base)
+            Result = Op.Opcode == NdOp::INT_ADD
+                         ? std::optional<int64_t>(*Base +
+                                                    static_cast<int64_t>(A.ConstVal))
+                         : std::nullopt;
+        } else if (!A.isConst() && B.isConst()) {
+          auto Base = Eval(A);
+          if (Base)
+            Result = Op.Opcode == NdOp::INT_ADD
+                         ? std::optional<int64_t>(*Base +
+                                                    static_cast<int64_t>(B.ConstVal))
+                         : std::optional<int64_t>(*Base -
+                                                    static_cast<int64_t>(B.ConstVal));
+        }
+      }
+      break;
+    case NdOp::LOAD: {
+      const MedVar *Address = safety::detail::memoryAddress(Op);
+      if (!Address || Op.Output.Size == 0)
+        break;
+      auto TargetOffset = Eval(*Address);
+      if (!TargetOffset)
+        break;
+      const MedBlock *LoadBlock = nullptr;
+      int LoadIndex = -1;
+      for (const auto &Block : Func.Blocks)
+        for (size_t I = 0; I < Block.Ops.size(); ++I)
+          if (&Block.Ops[I] == &Op) {
+            LoadBlock = &Block;
+            LoadIndex = static_cast<int>(I);
+          }
+      if (!LoadBlock)
+        break;
+
+      auto FindOp = [&](const MedVar &Value) -> const MedOp * {
+        auto DefIt = Definitions.find(entrySpKey(Value));
+        return DefIt == Definitions.end() || Ambiguous.count(entrySpKey(Value))
+                   ? nullptr
+                   : DefIt->second;
+      };
+      auto FindPhi = [&](const MedVar &Value) -> const PhiNode * {
+        auto PhiIt = Phis.find(entrySpKey(Value));
+        return PhiIt == Phis.end() || AmbiguousPhis.count(entrySpKey(Value))
+                   ? nullptr
+                   : PhiIt->second;
+      };
+      auto Resolve = [&](const MedVar &Value) { return Eval(Value); };
+      auto MayBeFrame = [&](const MedVar &Value) {
+        return safety::detail::aliasesWholeFrame(
+            Value, TRI.StackPointer, TRI.FramePointer, FindOp, FindPhi);
+      };
+      auto AliasesWholeFrame = [&](const MedVar &Value) {
+        return !Resolve(Value) && MayBeFrame(Value);
+      };
+      auto Reaching = safety::detail::reachingStackValues(
+          Func, LoadBlock->Id, LoadIndex, *TargetOffset, Op.Output.Size,
+          Resolve, MayBeFrame, AliasesWholeFrame);
+      if (!Reaching.Complete || Reaching.Values.empty())
+        break;
+      for (const MedVar &Source : Reaching.Values) {
+        auto Value = Eval(Source);
+        if (!Value || (Result && *Result != *Value)) {
+          Result.reset();
+          break;
+        }
+        Result = Value;
+      }
+      break;
+    }
+    default:
+      break;
+    }
+    Active.erase(Key);
+    return Result;
+  };
+
+  return Eval(Root);
+}
+} // namespace
 
 void recoverCallAbi(MedFunc &Func, Arch TheArch,
                     const std::map<va_t, std::string> &FuncNames,
                     const BinaryImage *Img,
-                    const std::map<va_t, int> *CalleeRegArity,
-                    const std::map<va_t, int> *CalleeTotalArity,
+                    std::map<va_t, int> *CalleeRegArity,
+                    std::map<va_t, int> *CalleeTotalArity,
                     const std::map<va_t, int> *CalleeFPArity,
                     const std::map<va_t, bool> *CalleeReturnsVec,
                     const std::map<va_t, std::vector<uint64_t>> *CalleeFPRegs,
                     const std::map<va_t, bool> *CalleeHasSret,
-                    const std::map<va_t, bool> *CalleeIsVariadic) {
+                    std::map<va_t, bool> *CalleeIsVariadic,
+                    const std::map<va_t, bool> *CalleeConsumesVaList) {
   Func.CallInfos.clear();
   (void)CalleeReturnsVec; // FP-return routing is modeled earlier (LowToMed)
 
@@ -929,7 +1088,97 @@ void recoverCallAbi(MedFunc &Func, Arch TheArch,
           }
         }
       }
-
+      // Walk transparent predecessor blocks until the last outgoing store. A
+      // synthetic PHI is inserted at each join so recovered values dominate
+      // the eventual call without treating unrelated stack writes as args.
+      if (!CI.IsIndirect && DarwinVarArgBase >= 0 &&
+          Blk.Preds.size() > 1 && TRI.PointerSize > 0) {
+        for (int Slot = 0; Slot < MaxArgs - DarwinVarArgBase; ++Slot) {
+          const int ArgIdx = DarwinVarArgBase + Slot;
+          if (ArgIdx < 0 || ArgIdx >= MaxArgs || FoundMask[ArgIdx])
+            continue;
+          const int64_t TargetOffset =
+              CallSpDelta + static_cast<int64_t>(Slot) * TRI.PointerSize;
+          std::function<std::optional<MedVar>(int, std::set<int> &)> Resolve =
+              [&](int BlockId, std::set<int> &Active) -> std::optional<MedVar> {
+            if (!Active.insert(BlockId).second)
+              return std::nullopt;
+            MedBlock *Block = nullptr;
+            for (auto &Candidate : Func.Blocks)
+              if (Candidate.Id == BlockId) {
+                Block = &Candidate;
+                break;
+              }
+            if (!Block) {
+              Active.erase(BlockId);
+              return std::nullopt;
+            }
+            const int Boundary = BlockId == Blk.Id
+                                  ? static_cast<int>(OI)
+                                  : static_cast<int>(Block->Ops.size());
+            for (int J = Boundary - 1; J >= 0; --J) {
+              const MedOp &Candidate = Block->Ops[J];
+              if (Candidate.Opcode == NdOp::CALL ||
+                  Candidate.Opcode == NdOp::INDIR_CALL ||
+                  Candidate.Opcode == NdOp::INTRINSIC) {
+                Active.erase(BlockId);
+                return std::nullopt;
+              }
+              if (Candidate.Opcode != NdOp::STORE ||
+                  Candidate.NumInputs < 2)
+                continue;
+              auto D = stackPtrDelta(*Block, TRI, Candidate.Inputs[0]);
+              if (D && *D == TargetOffset) {
+                MedVar Value = Candidate.Inputs[1];
+                Active.erase(BlockId);
+                return Value;
+              }
+            }
+            if (Block->Preds.empty()) {
+              Active.erase(BlockId);
+              return std::nullopt;
+            }
+            std::vector<std::pair<int, MedVar>> Incoming;
+            for (int PredId : Block->Preds) {
+              auto Value = Resolve(PredId, Active);
+              if (!Value) {
+                Active.erase(BlockId);
+                return std::nullopt;
+              }
+              Incoming.emplace_back(PredId, *Value);
+            }
+            MedVar Merged = Incoming.front().second;
+            bool Same = true;
+            for (const auto &[PredId, Value] : Incoming) {
+              (void)PredId;
+              if (Value != Merged) {
+                Same = false;
+                break;
+              }
+            }
+            if (!Same) {
+              Merged.Kind = MedVar::Temp;
+              Merged.Id = FreshId++;
+              Merged.SSAVer = 0;
+              Merged.Size = static_cast<uint16_t>(TRI.PointerSize);
+              Merged.TheArch = TheArch;
+              PhiNode Merge;
+              Merge.Output = Merged;
+              Merge.Args = std::move(Incoming);
+              Block->Phis.push_back(std::move(Merge));
+            }
+            Active.erase(BlockId);
+            return Merged;
+          };
+          std::set<int> Active;
+          auto Value = Resolve(Blk.Id, Active);
+          if (!Value)
+            continue;
+          Found[ArgIdx] = *Value;
+          FoundMask[ArgIdx] = true;
+          FromStackScan[ArgIdx] = true;
+        }
+      }
       // Tail-call forwarder: the callee's stack arguments are passed straight
       // through from this function's own incoming stack frame (the original
       // `jmp callee`, rewritten to CALL+RETURN, reuses it), so no store exists
@@ -1346,6 +1595,50 @@ void recoverCallAbi(MedFunc &Func, Arch TheArch,
       for (auto &A : StackPart)
         CI.Args.push_back(A);
 
+      // A Darwin wrapper is variadic only when its exact recovered call argument
+      // to a known va_list consumer is a pointer-width value derived from the
+      // entry SP.  CI.Args is SSA-bound at this call site, so a later write to
+      // x2/x3 cannot be mistaken for the consumed va_list.  Ordinary variadic
+      // calls and ambiguous provenance remain unmarked.
+      if (!CI.IsIndirect && Img && Img->isMachO() &&
+          TheArch == Arch::AArch64 && !CI.Args.empty()) {
+        const llvm::StringRef Bare = stripLeadingUnderscores(CI.TargetName);
+        const bool InternalVaListConsumer =
+            CalleeConsumesVaList &&
+            CalleeConsumesVaList->count(CI.TargetAddr) != 0 &&
+            CalleeConsumesVaList->at(CI.TargetAddr);
+        if ((libc::isVaListConsumer(Bare) || InternalVaListConsumer) &&
+            (InternalVaListConsumer || ExternalArity) &&
+            (InternalVaListConsumer ||
+             static_cast<int>(CI.Args.size()) == ExternalArity->IntArgs)) {
+          const MedVar &VaListArg = CI.Args.back();
+          if ((VaListArg.Kind == MedVar::Reg ||
+               VaListArg.Kind == MedVar::Temp) &&
+              VaListArg.Size == TRI.PointerSize) {
+            if (auto Delta = exactEntrySpDelta(Func, TheArch, VaListArg);
+                Delta && *Delta >= 0 &&
+                *Delta <= limits::kVariadicOverflowBaseMax &&
+                TRI.PointerSize > 0 &&
+                (*Delta % TRI.PointerSize) == 0) {
+              Func.IsVariadic = true;
+              Func.VariadicOverflowBase = *Delta;
+              if (InternalVaListConsumer) {
+                const int FixedPrefix =
+                    std::max(0, static_cast<int>(CI.Args.size()) - 1);
+                if (CalleeRegArity &&
+                    (*CalleeRegArity)[Func.Entry] < FixedPrefix)
+                  (*CalleeRegArity)[Func.Entry] = FixedPrefix;
+                if (CalleeTotalArity &&
+                    (*CalleeTotalArity)[Func.Entry] < FixedPrefix)
+                  (*CalleeTotalArity)[Func.Entry] = FixedPrefix;
+                if (CalleeIsVariadic)
+                  (*CalleeIsVariadic)[Func.Entry] = true;
+              }
+            }
+          }
+        }
+      }
+
       // Darwin AArch64 indirect variadic: a function pointer call with a
       // partial register prefix and separate stack-scalar outgoing stores
       // (`fp(n, a, b, c, d)`).  Mark the fixed prefix so the emitter declares
@@ -1434,7 +1727,6 @@ void recoverCallAbi(MedFunc &Func, Arch TheArch,
 
       if (!CI.IsIndirect && DarwinVarArgBase >= 0)
         CI.VarArgFixedCount = DarwinVarArgBase;
-
       Func.CallInfos.push_back(std::move(CI));
       if (!CallLaneOps.empty())
         Pending.push_back(
@@ -1492,20 +1784,20 @@ void recoverCallAbi(MedFunc &Func, Arch TheArch,
   // `f(a){return g(a);}` never reads its argument register (it flows straight
   // into the call), so detectCc's live-in scan misses it and Func.Params lacks
   // it.  The live-in fallback above recovered exactly those registers into
-  // PromoteParams; surface them so the function signature preserves the
-  // incoming value and the emitter resolves the call argument to the real
-  // parameter rather than an uninitialised register (0).  Done only when no
-  // integer register parameter was already detected, to leave a function whose
-  // register parameters are known untouched.
-  bool HasIntRegParam = false;
-  for (const auto &P : Func.Params)
-    if (P.RegOff != kNoParamReg && regToIntArgIdx(P.RegOff) >= 0) {
-      HasIntRegParam = true;
-      break;
-    }
-  if (!HasIntRegParam && !PromoteParams.empty()) {
-    std::vector<MedVar> RegParams;
-    for (int I = 0; I <= PromoteParams.rbegin()->first; ++I) {
+  // PromoteParams; add only missing register parameters.  A forwarder can
+  // already have a lower-index parameter (B5B4 has x0) while higher-index
+  // arguments (x1/x2) remain implicit live-ins.
+  if (!PromoteParams.empty()) {
+    std::set<int> ExistingIntArgs;
+    for (const auto &P : Func.Params)
+      if (P.RegOff != kNoParamReg)
+        if (int ArgIdx = regToIntArgIdx(P.RegOff); ArgIdx >= 0)
+          ExistingIntArgs.insert(ArgIdx);
+    const int MaxPromoted = PromoteParams.rbegin()->first;
+    for (int I = 0; I <= MaxPromoted &&
+         I < static_cast<int>(IntParamRegs.size()); ++I) {
+      if (ExistingIntArgs.count(I))
+        continue;
       MedVar P;
       P.Kind = MedVar::Param;
       P.Id = -1;
@@ -1518,17 +1810,23 @@ void recoverCallAbi(MedFunc &Func, Arch TheArch,
         P.RegOff = IntParamRegs[I];
         P.Size = TRI.FullRegWidth;
       }
-      RegParams.push_back(P);
+      auto InsertAt = Func.Params.begin();
+      while (InsertAt != Func.Params.end()) {
+        if (InsertAt->RegOff == kNoParamReg)
+          break;
+        const int ExistingIdx = regToIntArgIdx(InsertAt->RegOff);
+        if (ExistingIdx < 0 || ExistingIdx >= I)
+          break;
+        ++InsertAt;
+      }
+      const int InsertIndex =
+          static_cast<int>(std::distance(Func.Params.begin(), InsertAt));
+      Func.Params.insert(InsertAt, P);
+      for (auto &Home : Func.MutableStackParamHomes)
+        if (Home.first >= InsertIndex)
+          ++Home.first;
+      ExistingIntArgs.insert(I);
     }
-    // MutableStackParamHomes stores positions in Func.Params, not the
-    // stack-parameter MedVar ids.  Promoting a forwarded register prefix shifts
-    // every existing stack parameter to the right; rebase the positional
-    // metadata before inserting that prefix so the emitter seeds each home
-    // from its original incoming stack argument.
-    const int ParamIndexShift = static_cast<int>(RegParams.size());
-    for (auto &Home : Func.MutableStackParamHomes)
-      Home.first += ParamIndexShift;
-    Func.Params.insert(Func.Params.begin(), RegParams.begin(), RegParams.end());
   }
 
   // Surface forwarded incoming FP/vector registers as parameters (the FP dual

--- a/lib/ir/med/abi/MedCallingConv.cpp
+++ b/lib/ir/med/abi/MedCallingConv.cpp
@@ -594,22 +594,67 @@ void detectStackParams(MedFunc &Func, Arch TargetArch,
     ++Leading;
   }
 
+  using ValueKey = med_calling_conv_detail::ValueKey;
+  std::map<ValueKey, const MedOp *> UniqueDefs;
+  std::set<ValueKey> AmbiguousDefs;
+  for (const auto &Block : Func.Blocks)
+    for (const auto &Op : Block.Ops) {
+      if (Op.Output.isConst())
+        continue;
+      const ValueKey Key = med_calling_conv_detail::valueKey(Op.Output);
+      auto [It, Inserted] = UniqueDefs.emplace(Key, &Op);
+      if (!Inserted && It->second != &Op)
+        AmbiguousDefs.insert(Key);
+    }
+
   auto findDef = [&](const MedVar &V) -> const MedOp * {
-    for (const auto &Blk : Func.Blocks)
-      for (const auto &Op : Blk.Ops)
-        if (Op.Output.Kind == V.Kind && Op.Output.Id == V.Id &&
-            Op.Output.SSAVer == V.SSAVer)
-          return &Op;
-    return nullptr;
+    const ValueKey Key = med_calling_conv_detail::valueKey(V);
+    if (AmbiguousDefs.count(Key))
+      return nullptr;
+    auto It = UniqueDefs.find(Key);
+    return It == UniqueDefs.end() ? nullptr : It->second;
   };
+  std::map<ValueKey, const PhiNode *> UniquePhis;
+  std::set<ValueKey> AmbiguousPhis;
+  for (const auto &Block : Func.Blocks)
+    for (const auto &Phi : Block.Phis) {
+      const ValueKey Key = med_calling_conv_detail::valueKey(Phi.Output);
+      auto [It, Inserted] = UniquePhis.emplace(Key, &Phi);
+      if (!Inserted && It->second != &Phi)
+        AmbiguousPhis.insert(Key);
+    }
 
   // Offset of \p V relative to the entry stack pointer (folding the COPY /
   // zext / subpiece / push-sub chain detectCc sees before copy propagation),
   // or nullopt when V is not entry-SP-derived.
+  std::set<ValueKey> ActiveTrace;
   std::function<std::optional<int64_t>(const MedVar &, int)> traceOff =
       [&](const MedVar &V, int Depth) -> std::optional<int64_t> {
     if (Depth > 64)
       return std::nullopt;
+    const ValueKey Key = med_calling_conv_detail::valueKey(V);
+    if (!ActiveTrace.insert(Key).second)
+      return std::nullopt;
+    struct PopActive {
+      std::set<ValueKey> &Set;
+      ValueKey Key;
+      ~PopActive() { Set.erase(Key); }
+    } Guard{ActiveTrace, Key};
+
+    if (AmbiguousPhis.count(Key))
+      return std::nullopt;
+    if (auto It = UniquePhis.find(Key); It != UniquePhis.end()) {
+      std::optional<int64_t> Merged;
+      for (const auto &[Pred, Arg] : It->second->Args) {
+        (void)Pred;
+        auto Offset = traceOff(Arg, Depth + 1);
+        if (!Offset || (Merged && *Merged != *Offset))
+          return std::nullopt;
+        Merged = Offset;
+      }
+      return Merged;
+    }
+
     const MedOp *Def = findDef(V);
     if (!Def)
       return (V.Kind == MedVar::Reg && V.RegOff == SpOff)

--- a/lib/ir/med/abi/MedVariadic.cpp
+++ b/lib/ir/med/abi/MedVariadic.cpp
@@ -30,8 +30,10 @@
 #include "llvm/ADT/SmallVector.h"
 
 #include <functional>
+#include <map>
 #include <optional>
 #include <set>
+#include <tuple>
 
 namespace neverd {
 
@@ -40,69 +42,112 @@ using med_calling_conv_detail::containsValue;
 
 namespace {
 
-// Byte offset of \p V relative to the entry stack pointer, following the SP
-// definition chain across the whole function.  Runs before copy propagation
-// (detectCc time), so the def may sit in any block; PHIs end the trace. nullopt
-// when V is not entry-SP-derived.
+// Byte offset of \p V relative to the entry stack pointer. Every SSA/PHI
+// definition must be unique and every PHI arm must prove the same offset.
 std::optional<int64_t> entrySpDelta(const MedFunc &Func, uint64_t SpOff,
-                                    const MedVar &V, int Depth) {
-  if (Depth > 64 || V.isConst())
-    return std::nullopt;
-  const MedOp *Def = nullptr;
-  for (const auto &Blk : Func.Blocks) {
-    for (const auto &Op : Blk.Ops)
-      if (Op.Output.Kind == V.Kind && Op.Output.Id == V.Id &&
-          Op.Output.SSAVer == V.SSAVer && Op.Output.RegOff == V.RegOff) {
-        Def = &Op;
-        break;
-      }
-    if (Def)
-      break;
-  }
-  if (!Def)
-    return (V.Kind == MedVar::Reg && V.RegOff == SpOff)
-               ? std::optional<int64_t>(0)
-               : std::nullopt;
-  auto constOf = [](const MedVar &X) -> std::optional<int64_t> {
-    return X.isConst()
-               ? std::optional<int64_t>(static_cast<int64_t>(X.ConstVal))
-               : std::nullopt;
+                                    const MedVar &Root, int Depth) {
+  using Key = std::tuple<uint8_t, int, int, uint64_t, uint16_t>;
+  auto keyOf = [](const MedVar &Value) -> Key {
+    return {static_cast<uint8_t>(Value.Kind), Value.Id, Value.SSAVer,
+            Value.Kind == MedVar::Reg ? Value.RegOff : 0, Value.Size};
   };
-  switch (Def->Opcode) {
-  case NdOp::COPY:
-    if (Def->NumInputs >= 1) {
-      const MedVar &In = Def->Inputs[0];
-      if (In.Kind == MedVar::Reg && In.RegOff == SpOff && In.Id == V.Id &&
-          In.SSAVer == V.SSAVer)
-        return 0;
-      return entrySpDelta(Func, SpOff, In, Depth + 1);
+  std::map<Key, const MedOp *> Definitions;
+  std::set<Key> AmbiguousDefinitions;
+  std::map<Key, const PhiNode *> Phis;
+  std::set<Key> AmbiguousPhis;
+  for (const auto &Block : Func.Blocks) {
+    for (const auto &Op : Block.Ops) {
+      if (Op.Output.isConst())
+        continue;
+      const Key K = keyOf(Op.Output);
+      auto [It, Inserted] = Definitions.emplace(K, &Op);
+      if (!Inserted && It->second != &Op)
+        AmbiguousDefinitions.insert(K);
     }
-    return std::nullopt;
-  case NdOp::INT_ZEXT:
-  case NdOp::INT_SEXT:
-  case NdOp::SUBBYTES:
-    return Def->NumInputs >= 1
-               ? entrySpDelta(Func, SpOff, Def->Inputs[0], Depth + 1)
-               : std::nullopt;
-  case NdOp::INT_ADD:
-    if (Def->NumInputs >= 2) {
-      if (auto C = constOf(Def->Inputs[1]))
-        if (auto B = entrySpDelta(Func, SpOff, Def->Inputs[0], Depth + 1))
-          return *B + *C;
-      if (auto C = constOf(Def->Inputs[0]))
-        if (auto B = entrySpDelta(Func, SpOff, Def->Inputs[1], Depth + 1))
-          return *B + *C;
+    for (const auto &Phi : Block.Phis) {
+      const Key K = keyOf(Phi.Output);
+      auto [It, Inserted] = Phis.emplace(K, &Phi);
+      if (!Inserted && It->second != &Phi)
+        AmbiguousPhis.insert(K);
     }
-    return std::nullopt;
-  case NdOp::INT_SUB:
-    if (Def->NumInputs >= 2)
-      if (auto C = constOf(Def->Inputs[1]))
-        if (auto B = entrySpDelta(Func, SpOff, Def->Inputs[0], Depth + 1))
-          return *B - *C;
-    return std::nullopt;
-  default:
-    return std::nullopt;
   }
+
+  std::set<Key> Active;
+  std::function<std::optional<int64_t>(const MedVar &, int)> Eval =
+      [&](const MedVar &V, int Remaining) -> std::optional<int64_t> {
+    if (Remaining <= 0 || V.isConst()) {
+      if (V.isConst() &&
+          (V.Provenance == ConstantAddressProvenance::Unknown ||
+           V.Provenance == ConstantAddressProvenance::Scalar))
+        return static_cast<int64_t>(V.ConstVal);
+      return std::nullopt;
+    }
+    if (V.Kind != MedVar::Reg && V.Kind != MedVar::Temp)
+      return std::nullopt;
+    if (V.Kind == MedVar::Reg && V.RegOff == SpOff && V.SSAVer == 0)
+      return int64_t{0};
+
+    const Key K = keyOf(V);
+    if (!Active.insert(K).second || AmbiguousDefinitions.count(K) ||
+        AmbiguousPhis.count(K))
+      return std::nullopt;
+    struct PopActive {
+      std::set<Key> &Set;
+      Key Value;
+      ~PopActive() { Set.erase(Value); }
+    } Guard{Active, K};
+
+    if (auto It = Phis.find(K); It != Phis.end()) {
+      std::optional<int64_t> Merged;
+      for (const auto &[Pred, Arg] : It->second->Args) {
+        (void)Pred;
+        auto Offset = Eval(Arg, Remaining - 1);
+        if (!Offset || (Merged && *Merged != *Offset))
+          return std::nullopt;
+        Merged = Offset;
+      }
+      return Merged;
+    }
+    auto It = Definitions.find(K);
+    if (It == Definitions.end())
+      return std::nullopt;
+    const MedOp &Op = *It->second;
+    auto constOf = [](const MedVar &Value) -> std::optional<int64_t> {
+      if (!Value.isConst() ||
+          (Value.Provenance != ConstantAddressProvenance::Unknown &&
+           Value.Provenance != ConstantAddressProvenance::Scalar))
+        return std::nullopt;
+      return static_cast<int64_t>(Value.ConstVal);
+    };
+    if (Op.NumInputs < 1)
+      return std::nullopt;
+    switch (Op.Opcode) {
+    case NdOp::COPY:
+    case NdOp::INT_ZEXT:
+    case NdOp::INT_SEXT:
+      return Eval(Op.Inputs[0], Remaining - 1);
+    case NdOp::SUBBYTES:
+      return Op.NumInputs >= 2 && Op.Inputs[1].isConst() &&
+                     Op.Inputs[1].ConstVal == 0
+                 ? Eval(Op.Inputs[0], Remaining - 1)
+                 : std::nullopt;
+    case NdOp::INT_ADD:
+    case NdOp::INT_SUB:
+      if (Op.NumInputs < 2)
+        return std::nullopt;
+      if (auto C = constOf(Op.Inputs[1]))
+        if (auto Base = Eval(Op.Inputs[0], Remaining - 1))
+          return Op.Opcode == NdOp::INT_ADD ? *Base + *C : *Base - *C;
+      if (Op.Opcode == NdOp::INT_ADD)
+        if (auto C = constOf(Op.Inputs[0]))
+          if (auto Base = Eval(Op.Inputs[1], Remaining - 1))
+            return *Base + *C;
+      return std::nullopt;
+    default:
+      return std::nullopt;
+    }
+  };
+  return Eval(Root, Depth > 0 ? 64 - Depth : 64);
 }
 
 // Whether \p V is the x86-64 SysV va_start word ((fp_offset << 32) | gp_offset)
@@ -206,7 +251,8 @@ void detectVariadic(MedFunc &Func, const TargetRegInfo &TRI, Arch TargetArch,
       std::set<int64_t> HomeSlots;
       for (const auto &Blk : Func.Blocks)
         for (const auto &Op : Blk.Ops)
-          if (Op.Opcode == NdOp::STORE && Op.NumInputs >= 2)
+          if (Op.Opcode == NdOp::STORE && Op.NumInputs >= 2 &&
+              !Op.Inputs[1].isConst())
             if (auto VD = entrySpDelta(Func, SpOff, Op.Inputs[1], 0))
               if (*VD >= 0 && *VD <= limits::kVariadicOverflowBaseMax &&
                   TRI.PointerSize > 0 && (*VD % TRI.PointerSize) == 0)
@@ -421,10 +467,8 @@ void detectVariadic(MedFunc &Func, const TargetRegInfo &TRI, Arch TargetArch,
           UsedAsLoad = true;
     Marked = !HomeSlots.empty() && (Reloaded || UsedAsLoad);
   }
-
   if (!Marked)
     return;
-
   // The overflow area base: the smallest non-negative entry-SP offset stored as
   // a pointer value (the va_list overflow/__stack pointer).  x86-64 places it
   // one slot past the return address (+8); AArch64 at the entry SP (+0).  The

--- a/lib/ir/med/lower/LowToMedCallReturnFP.cpp
+++ b/lib/ir/med/lower/LowToMedCallReturnFP.cpp
@@ -109,6 +109,9 @@ void LowToMedConverter::modelCallFPReturn(MedFunc &Func) {
            Op.Inputs[1].RegOff == FPRet && Op.Inputs[0].Id == Op.Inputs[1].Id &&
            Op.Inputs[0].SSAVer == Op.Inputs[1].SSAVer;
   };
+  auto isCall = [](const MedOp &Op) {
+    return Op.Opcode == NdOp::CALL || Op.Opcode == NdOp::INDIR_CALL;
+  };
 
   // SSA publishes the authoritative caller-saved definitions per exact call
   // site.  Use that record instead of treating every call as a barrier: stack
@@ -155,6 +158,8 @@ void LowToMedConverter::modelCallFPReturn(MedFunc &Func) {
           continue;
         const MedVar &PV = Phi.Output;
         for (const auto &Nx : B.Ops) {
+          if (isCall(Nx))
+            break;
           if (!isFPRetSelfZero(Nx))
             for (uint8_t I = 0; I < Nx.NumInputs; ++I)
               if (Nx.Inputs[I].Kind == MedVar::Reg &&
@@ -206,6 +211,10 @@ void LowToMedConverter::modelCallFPReturn(MedFunc &Func) {
         continue;
       bool Redef = false;
       for (const auto &Nx : SB->Ops) {
+        if (isCall(Nx)) {
+          Redef = true;
+          break;
+        }
         if (!isFPRetSelfZero(Nx))
           for (uint8_t I = 0; I < Nx.NumInputs; ++I)
             if (Nx.Inputs[I].Kind == MedVar::Reg &&
@@ -246,6 +255,8 @@ void LowToMedConverter::modelCallFPReturn(MedFunc &Func) {
       bool ReadAfter = false, RedefAfter = false;
       for (size_t J = OI + 1; J < Blk.Ops.size(); ++J) {
         auto &Nx = Blk.Ops[J];
+        if (isCall(Nx))
+          break;
         // `xorps xmm0,xmm0` / `subss x,x` zeroes the register: it reads FPRet
         // only to discard it (result is 0, independent of the value), so it is
         // a redefinition, not a consumption of the call's FP return.  An
@@ -304,6 +315,10 @@ void LowToMedConverter::modelCallFPReturn(MedFunc &Func) {
       bool LaterRedef = false;
       for (size_t J = OI + 1; J < Blk.Ops.size(); ++J) {
         auto &Nx = Blk.Ops[J];
+        if (isCall(Nx)) {
+          LaterRedef = true;
+          break;
+        }
         for (uint8_t I = 0; I < Nx.NumInputs; ++I)
           if (Nx.Inputs[I].Kind == MedVar::Reg &&
               Nx.Inputs[I].RegOff == FPRet) {
@@ -354,6 +369,10 @@ void LowToMedConverter::modelCallFPReturn(MedFunc &Func) {
             continue; // the PHI (updated below) carries the value
           bool Redef = false;
           for (auto &Nx : SB->Ops) {
+            if (isCall(Nx)) {
+              Redef = true;
+              break;
+            }
             for (uint8_t I = 0; I < Nx.NumInputs; ++I)
               if (Nx.Inputs[I].Kind == MedVar::Reg &&
                   Nx.Inputs[I].RegOff == FPRet) {

--- a/lib/ir/med/lower/LowToMedCallReturnFP.cpp
+++ b/lib/ir/med/lower/LowToMedCallReturnFP.cpp
@@ -109,9 +109,6 @@ void LowToMedConverter::modelCallFPReturn(MedFunc &Func) {
            Op.Inputs[1].RegOff == FPRet && Op.Inputs[0].Id == Op.Inputs[1].Id &&
            Op.Inputs[0].SSAVer == Op.Inputs[1].SSAVer;
   };
-  auto isCall = [](const MedOp &Op) {
-    return Op.Opcode == NdOp::CALL || Op.Opcode == NdOp::INDIR_CALL;
-  };
 
   // SSA publishes the authoritative caller-saved definitions per exact call
   // site.  Use that record instead of treating every call as a barrier: stack
@@ -158,8 +155,6 @@ void LowToMedConverter::modelCallFPReturn(MedFunc &Func) {
           continue;
         const MedVar &PV = Phi.Output;
         for (const auto &Nx : B.Ops) {
-          if (isCall(Nx))
-            break;
           if (!isFPRetSelfZero(Nx))
             for (uint8_t I = 0; I < Nx.NumInputs; ++I)
               if (Nx.Inputs[I].Kind == MedVar::Reg &&
@@ -211,10 +206,6 @@ void LowToMedConverter::modelCallFPReturn(MedFunc &Func) {
         continue;
       bool Redef = false;
       for (const auto &Nx : SB->Ops) {
-        if (isCall(Nx)) {
-          Redef = true;
-          break;
-        }
         if (!isFPRetSelfZero(Nx))
           for (uint8_t I = 0; I < Nx.NumInputs; ++I)
             if (Nx.Inputs[I].Kind == MedVar::Reg &&
@@ -255,8 +246,6 @@ void LowToMedConverter::modelCallFPReturn(MedFunc &Func) {
       bool ReadAfter = false, RedefAfter = false;
       for (size_t J = OI + 1; J < Blk.Ops.size(); ++J) {
         auto &Nx = Blk.Ops[J];
-        if (isCall(Nx))
-          break;
         // `xorps xmm0,xmm0` / `subss x,x` zeroes the register: it reads FPRet
         // only to discard it (result is 0, independent of the value), so it is
         // a redefinition, not a consumption of the call's FP return.  An
@@ -315,10 +304,6 @@ void LowToMedConverter::modelCallFPReturn(MedFunc &Func) {
       bool LaterRedef = false;
       for (size_t J = OI + 1; J < Blk.Ops.size(); ++J) {
         auto &Nx = Blk.Ops[J];
-        if (isCall(Nx)) {
-          LaterRedef = true;
-          break;
-        }
         for (uint8_t I = 0; I < Nx.NumInputs; ++I)
           if (Nx.Inputs[I].Kind == MedVar::Reg &&
               Nx.Inputs[I].RegOff == FPRet) {
@@ -369,10 +354,6 @@ void LowToMedConverter::modelCallFPReturn(MedFunc &Func) {
             continue; // the PHI (updated below) carries the value
           bool Redef = false;
           for (auto &Nx : SB->Ops) {
-            if (isCall(Nx)) {
-              Redef = true;
-              break;
-            }
             for (uint8_t I = 0; I < Nx.NumInputs; ++I)
               if (Nx.Inputs[I].Kind == MedVar::Reg &&
                   Nx.Inputs[I].RegOff == FPRet) {

--- a/lib/pipeline/PipelinePatchLift.cpp
+++ b/lib/pipeline/PipelinePatchLift.cpp
@@ -97,7 +97,8 @@ static void propagateForwardedCallArities(
     const std::map<va_t, bool> &CalleeReturnsVec,
     std::map<va_t, std::vector<uint64_t>> &CalleeFPRegs,
     const std::map<va_t, bool> &CalleeHasSret,
-    const std::map<va_t, bool> &CalleeIsVariadic) {
+    std::map<va_t, bool> &CalleeIsVariadic,
+    const std::map<va_t, bool> &CalleeConsumesVaList) {
   if (Funcs.empty())
     return;
 
@@ -123,11 +124,16 @@ static void propagateForwardedCallArities(
     Work.pop();
     Queued[I] = false;
 
+    const int PreviousRegArity = CalleeRegArity[Funcs[I].Entry];
+    const int PreviousTotalArity = CalleeTotalArity[Funcs[I].Entry];
+    const bool PreviousVariadic =
+        CalleeIsVariadic.count(Funcs[I].Entry) != 0 &&
+        CalleeIsVariadic.at(Funcs[I].Entry);
     MedFunc Probe = Funcs[I];
     recoverCallAbi(Probe, TheArch, FuncNames, &Img, &CalleeRegArity,
                    &CalleeTotalArity, &CalleeFPArity, &CalleeReturnsVec,
-                   &CalleeFPRegs, &CalleeHasSret, &CalleeIsVariadic);
-
+                   &CalleeFPRegs, &CalleeHasSret, &CalleeIsVariadic,
+                   &CalleeConsumesVaList);
     int MaxRegIdx = -1;
     int MaxIdx = -1;
     std::vector<uint64_t> FPRegs;
@@ -148,21 +154,33 @@ static void propagateForwardedCallArities(
     std::sort(FPRegs.begin(), FPRegs.end());
 
     const int RegArity = MaxRegIdx + 1;
-    const int TotalArity = callRecoveryTotalArity(Probe, MaxIdx);
+    const bool IsVariadicPublic =
+        Probe.IsVariadic ||
+        (CalleeIsVariadic.count(Probe.Entry) != 0 &&
+         CalleeIsVariadic.at(Probe.Entry));
+    const int TotalArity = IsVariadicPublic ? MaxIdx + 1
+                                            : callRecoveryTotalArity(Probe, MaxIdx);
     const int FPArity = static_cast<int>(FPRegs.size());
-    bool Grew = false;
+    if (IsVariadicPublic)
+      CalleeIsVariadic[Probe.Entry] = true;
+    bool Grew = CalleeRegArity[Probe.Entry] > PreviousRegArity ||
+                 CalleeTotalArity[Probe.Entry] > PreviousTotalArity ||
+                 (CalleeIsVariadic.count(Probe.Entry) != 0 &&
+                  CalleeIsVariadic.at(Probe.Entry) != PreviousVariadic);
     if (RegArity > CalleeRegArity[Probe.Entry]) {
       CalleeRegArity[Probe.Entry] = RegArity;
       Grew = true;
     }
-    if (TotalArity > CalleeTotalArity[Probe.Entry]) {
-      CalleeTotalArity[Probe.Entry] = TotalArity;
-      Grew = true;
-    }
-    if (FPArity > CalleeFPArity[Probe.Entry]) {
-      CalleeFPArity[Probe.Entry] = FPArity;
-      CalleeFPRegs[Probe.Entry] = std::move(FPRegs);
-      Grew = true;
+    if (!IsVariadicPublic) {
+      if (TotalArity > CalleeTotalArity[Probe.Entry]) {
+        CalleeTotalArity[Probe.Entry] = TotalArity;
+        Grew = true;
+      }
+      if (FPArity > CalleeFPArity[Probe.Entry]) {
+        CalleeFPArity[Probe.Entry] = FPArity;
+        CalleeFPRegs[Probe.Entry] = std::move(FPRegs);
+        Grew = true;
+      }
     }
     if (!Grew)
       continue;
@@ -292,6 +310,7 @@ bool Pipeline::runPatchLiftMode(const BinaryImage &Img, llvm::LLVMContext &Ctx,
   std::map<va_t, bool> CalleeReturnsVec;
   std::map<va_t, bool> CalleeHasSret;
   std::map<va_t, bool> CalleeIsVariadic;
+  std::map<va_t, bool> CalleeConsumesVaList;
   {
     const auto &TRI = getTargetRegInfo(Img.Arch);
     // On x86-64 a floating-point return lands in XMM0 (a vector register); on
@@ -326,6 +345,18 @@ bool Pipeline::runPatchLiftMode(const BinaryImage &Img, llvm::LLVMContext &Ctx,
           MaxIdx = std::max(MaxIdx, P.Id);
         }
       }
+      bool ConsumesVaList = false;
+      for (const auto &Blk : MF.Blocks)
+        for (const auto &Op : Blk.Ops)
+          if (Op.Opcode == NdOp::CALL && Op.NumInputs >= 1 &&
+              Op.Inputs[0].isConst()) {
+            if (const Import *Imp = Img.findImportAt(Op.Inputs[0].ConstVal)) {
+              if (libc::isVaListConsumer(
+                      stripLeadingUnderscores(Imp->Name)))
+                ConsumesVaList = true;
+            }
+          }
+      CalleeConsumesVaList[MF.Entry] = ConsumesVaList;
       std::sort(FPRegs.begin(), FPRegs.end());
       CalleeRegArity[MF.Entry] = MaxRegIdx + 1;
       CalleeTotalArity[MF.Entry] = callRecoveryTotalArity(MF, MaxIdx);
@@ -484,12 +515,13 @@ bool Pipeline::runPatchLiftMode(const BinaryImage &Img, llvm::LLVMContext &Ctx,
   propagateForwardedCallArities(Result.MedFuncs, Img.Arch, AllFuncNames, Img,
                                 CalleeRegArity, CalleeTotalArity, CalleeFPArity,
                                 CalleeReturnsVec, CalleeFPRegs, CalleeHasSret,
-                                CalleeIsVariadic);
+                                CalleeIsVariadic, CalleeConsumesVaList);
 
   for (auto &MF : Result.MedFuncs)
     recoverCallAbi(MF, Img.Arch, AllFuncNames, &Img, &CalleeRegArity,
                    &CalleeTotalArity, &CalleeFPArity, &CalleeReturnsVec,
-                   &CalleeFPRegs, &CalleeHasSret, &CalleeIsVariadic);
+                   &CalleeFPRegs, &CalleeHasSret, &CalleeIsVariadic,
+                   &CalleeConsumesVaList);
 
   remodelStructReturnForwarderCalls(Img, Result);
 
@@ -516,7 +548,8 @@ bool Pipeline::runPatchLiftMode(const BinaryImage &Img, llvm::LLVMContext &Ctx,
     for (auto &MF : Result.MedFuncs)
       recoverCallAbi(MF, Img.Arch, AllFuncNames, &Img, &CRA2, &CTA2,
                      &CalleeFPArity, &CalleeReturnsVec, &CalleeFPRegs,
-                     &CalleeHasSret, &CalleeIsVariadic);
+                     &CalleeHasSret, &CalleeIsVariadic,
+                     &CalleeConsumesVaList);
   }
 
   // Variadic callees: size each one's overflow stack-parameter list from its

--- a/unittests/libc/LibCNamesTests.cpp
+++ b/unittests/libc/LibCNamesTests.cpp
@@ -88,6 +88,12 @@ TEST(VarArgFixedCount, PosixWhitelist) {
   EXPECT_EQ(varArgFixedCount("sem_open"), 1u);
 }
 
+TEST(VarArgFixedParamKind, OpenPreservesPathAndFlags) {
+  EXPECT_EQ(varArgFixedParamKind("open", 0), VarArgFixedParamKind::Pointer);
+  EXPECT_EQ(varArgFixedParamKind("open", 1), VarArgFixedParamKind::Integer);
+  EXPECT_EQ(varArgFixedParamKind("open", 2), VarArgFixedParamKind::Unknown);
+}
+
 TEST(VarArgFixedCount, DarwinObjectiveCMessageStubs) {
   // The linker-specialized stub supplies _cmd in x1.  The external call still
   // models that register as part of the fixed prefix so method arguments start
@@ -252,6 +258,17 @@ TEST(LibCArity, ExceptionRuntimeFunctions) {
   ASSERT_TRUE(ObjCThrow.has_value());
   EXPECT_EQ(ObjCThrow->IntArgs, 1);
   EXPECT_EQ(ObjCThrow->FpArgs, 0);
+}
+
+TEST(LibCArity, VaListConsumersHaveFixedPrototypes) {
+  auto VPrintf = libcArity("vprintf");
+  ASSERT_TRUE(VPrintf.has_value());
+  EXPECT_EQ(VPrintf->IntArgs, 2);
+  EXPECT_EQ(VPrintf->FpArgs, 0);
+
+  auto Vsnprintf = libcArity("vsnprintf");
+  ASSERT_TRUE(Vsnprintf.has_value());
+  EXPECT_EQ(Vsnprintf->IntArgs, 3);
 }
 
 TEST(LibCArity, PreservesDarwinErrorSymbolSpelling) {

--- a/unittests/lift/aarch64/AArch64_CallAbiTests.cpp
+++ b/unittests/lift/aarch64/AArch64_CallAbiTests.cpp
@@ -91,6 +91,69 @@ TEST_F(AArch64_CallAbi, ExternalDarwinVarargsKeepOutgoingStackValues) {
       << F;
 }
 
+TEST_F(AArch64_CallAbi, DarwinVarargsAtJoinKeepAllOutgoingStackValues) {
+  if (!fs::exists(callAbiObj()))
+    GTEST_SKIP() << "AArch64 Mach-O ABI fixture is only built on Apple hosts";
+  auto R = liftToLLVMIRUnopt(callAbiObj());
+  ASSERT_EQ(R.exitCode, 0) << R.err;
+
+  std::string F = callAbiFunctionText(R.out, "joined_external_varargs");
+  ASSERT_FALSE(F.empty()) << R.out;
+  size_t Call = F.find("@printf(");
+  ASSERT_NE(Call, std::string::npos) << F;
+  size_t LineBegin = F.rfind('\n', Call);
+  size_t LineEnd = F.find('\n', Call);
+  std::string CallLine = F.substr(LineBegin + 1, LineEnd - LineBegin - 1);
+  size_t FirstArg = CallLine.find("i64 %");
+  ASSERT_NE(FirstArg, std::string::npos) << CallLine;
+  EXPECT_NE(CallLine.find("i64 %", FirstArg + 6), std::string::npos)
+      << CallLine;
+}
+
+TEST_F(AArch64_CallAbi, DarwinVaListForwarderUsesExactConsumerCertificate) {
+  if (!fs::exists(callAbiObj()))
+    GTEST_SKIP() << "AArch64 Mach-O ABI fixture is only built on Apple hosts";
+  auto R = liftToLLVMIRUnopt(callAbiObj());
+  ASSERT_EQ(R.exitCode, 0) << R.err;
+
+  std::string F = callAbiFunctionText(R.out, "forward_va_list");
+  ASSERT_FALSE(F.empty()) << R.out;
+  EXPECT_NE(F.find("@forward_va_list(i64"), std::string::npos) << F;
+  EXPECT_NE(F.find("..."), std::string::npos) << F;
+  EXPECT_NE(F.find("call i64 @vprintf(ptr"), std::string::npos) << F;
+}
+
+TEST_F(AArch64_CallAbi, DarwinVaListWrapperKeepsFixedRegisterPrefix) {
+  if (!fs::exists(callAbiObj()))
+    GTEST_SKIP() << "AArch64 Mach-O ABI fixture is only built on Apple hosts";
+  auto R = liftToLLVMIRUnopt(callAbiObj());
+  ASSERT_EQ(R.exitCode, 0) << R.err;
+
+  std::string Wrapper =
+      callAbiFunctionText(R.out, "forward_va_list_with_context");
+  ASSERT_FALSE(Wrapper.empty()) << R.out;
+  EXPECT_NE(Wrapper.find("@forward_va_list_with_context(i32 %arg0, i64 %arg1"),
+            std::string::npos)
+      << Wrapper;
+
+  std::string Caller =
+      callAbiFunctionText(R.out, "call_forward_va_list_with_context");
+  ASSERT_FALSE(Caller.empty()) << R.out;
+  size_t Call = Caller.find("@forward_va_list_with_context(");
+  ASSERT_NE(Call, std::string::npos) << Caller;
+  size_t LineBegin = Caller.rfind('\n', Call);
+  size_t LineEnd = Caller.find('\n', Call);
+  std::string CallLine = Caller.substr(LineBegin + 1, LineEnd - LineBegin - 1);
+  EXPECT_NE(CallLine.find("call i64 (i32, i64, i64, ...)"), std::string::npos)
+      << CallLine;
+  size_t ContextArg = CallLine.find("i32 %");
+  ASSERT_NE(ContextArg, std::string::npos) << CallLine;
+  size_t FixedArg = CallLine.find("i64 ", ContextArg);
+  ASSERT_NE(FixedArg, std::string::npos) << CallLine;
+  EXPECT_NE(CallLine.find("i64 ", FixedArg + 4), std::string::npos)
+      << CallLine;
+}
+
 TEST_F(AArch64_CallAbi, FixedPointerArgumentUsesFullWidthPhiAlias) {
   if (!fs::exists(callArgPhiMachOObj()))
     GTEST_SKIP() << "AArch64 Mach-O ABI fixture is only built on Apple hosts";

--- a/unittests/lift/aarch64/AArch64_FunctionDiscoveryTests.cpp
+++ b/unittests/lift/aarch64/AArch64_FunctionDiscoveryTests.cpp
@@ -93,6 +93,76 @@ TEST(AArch64FunctionDiscovery,
       0u);
 }
 
+TEST(AArch64FunctionDiscovery, VerifiesZeroSizedTypedFunctionStartInsideKnownRange) {
+  constexpr va_t ImageVA = 0x5000;
+  constexpr va_t TypedStartVA = ImageVA + 0x8;
+
+  BinaryImage Img;
+  Img.Arch = Arch::AArch64;
+  Img.Bits = Bitness::Bits64;
+  Img.Format = BinaryFormat::MachO;
+  Img.Base = ImageVA;
+  Img.Entry = ImageVA;
+
+  Segment Text;
+  Text.Name = "__TEXT";
+  Text.VA = ImageVA;
+  Text.Size = 0x10;
+  Text.Flags = SegmentFlags::Readable | SegmentFlags::Executable;
+  Text.Data.assign(Text.Size, 0);
+  writeLE<uint32_t>(Text.Data.data(), 0xD65F03C0u);
+  writeLE<uint32_t>(Text.Data.data() + (TypedStartVA - ImageVA),
+                    0xD65F03C0u);
+  Img.Segments.push_back(std::move(Text));
+  Img.Sections.push_back(
+      makeMachOSection("__text", ImageVA, 0x10, /*ContainsInstructions=*/true));
+  Img.KnownCodeRanges.emplace_back(ImageVA, ImageVA + 0x10);
+  Img.Symbols.push_back(Symbol::makeFunc(TypedStartVA));
+
+  Decoder Dec;
+  ASSERT_TRUE(Dec.init(Arch::AArch64));
+  FuncDetector Detector;
+  const auto Functions = Detector.detect(Img, Dec);
+
+  EXPECT_EQ(std::count_if(Functions.begin(), Functions.end(),
+                          [](const auto &F) { return F.first == TypedStartVA; }),
+            1u);
+}
+
+TEST(AArch64FunctionDiscovery, RejectsZeroSizedTypedFunctionStartWithBadCode) {
+  constexpr va_t ImageVA = 0x6000;
+  constexpr va_t TypedStartVA = ImageVA + 0x8;
+
+  BinaryImage Img;
+  Img.Arch = Arch::AArch64;
+  Img.Bits = Bitness::Bits64;
+  Img.Format = BinaryFormat::MachO;
+  Img.Base = ImageVA;
+  Img.Entry = ImageVA;
+
+  Segment Text;
+  Text.Name = "__TEXT";
+  Text.VA = ImageVA;
+  Text.Size = 0x10;
+  Text.Flags = SegmentFlags::Readable | SegmentFlags::Executable;
+  Text.Data.assign(Text.Size, 0);
+  writeLE<uint32_t>(Text.Data.data(), 0xD65F03C0u);
+  Img.Segments.push_back(std::move(Text));
+  Img.Sections.push_back(
+      makeMachOSection("__text", ImageVA, 0x10, /*ContainsInstructions=*/true));
+  Img.KnownCodeRanges.emplace_back(ImageVA, ImageVA + 0x10);
+  Img.Symbols.push_back(Symbol::makeFunc(TypedStartVA));
+
+  Decoder Dec;
+  ASSERT_TRUE(Dec.init(Arch::AArch64));
+  FuncDetector Detector;
+  const auto Functions = Detector.detect(Img, Dec);
+
+  EXPECT_EQ(std::count_if(Functions.begin(), Functions.end(),
+                          [](const auto &F) { return F.first == TypedStartVA; }),
+            0u);
+}
+
 TEST(AArch64FunctionDiscovery,
      X64CallScanRejectsDataAndCodeToDataBoundaryPatterns) {
   constexpr va_t ImageVA = 0x3000;

--- a/unittests/lift/aarch64/test_call_abi_a64_macho.c
+++ b/unittests/lift/aarch64/test_call_abi_a64_macho.c
@@ -11,6 +11,8 @@ typedef struct {
 extern Pair make_external_pair(void);
 extern u64 sum_external_varargs(u64 first, ...);
 extern int *__error(void);
+extern int printf(const char *, ...);
+extern int vprintf(const char *, __builtin_va_list);
 
 __attribute__((noinline)) double indirect_double_call(double value,
                                                       double_fn fn) {
@@ -31,6 +33,28 @@ __attribute__((noinline)) u64 direct_external_varargs(void) {
   return sum_external_varargs(0x10ULL, 0x20ULL, 0x30ULL);
 }
 
+__attribute__((noinline)) int forward_va_list(const char *fmt, ...) {
+  __builtin_va_list ap;
+  __builtin_va_start(ap, fmt);
+  int result = vprintf(fmt, ap);
+  __builtin_va_end(ap);
+  return result;
+}
+
+__attribute__((noinline)) int forward_va_list_with_context(int context,
+                                                     const char *fmt, ...) {
+  __builtin_va_list ap;
+  __builtin_va_start(ap, fmt);
+  int result = vprintf(fmt, ap);
+  __builtin_va_end(ap);
+  return result + context;
+}
+
+__attribute__((noinline)) int call_forward_va_list_with_context(int context,
+                                                       const char *value) {
+  return forward_va_list_with_context(context, "%s", value);
+}
+
 __attribute__((noinline)) int external_error_compute(int a, int b, int c,
                                                      int d, int e, int f,
                                                      int g) {
@@ -46,6 +70,19 @@ __attribute__((noinline)) int external_error_simple(void) {
   return *__error();
 }
 
+__attribute__((noinline)) int joined_external_varargs(int flag,
+                                                     const char *value) {
+  const char *selected;
+  int separator;
+  if (flag) {
+    selected = value;
+    separator = ':';
+  } else {
+    selected = value;
+    separator = ',';
+  }
+  return printf("%s%c", selected, separator);
+}
 __attribute__((noinline, noreturn)) void neverd_fail(void) { __builtin_trap(); }
 
 __attribute__((noinline)) int neverd_after_fail(int value) {

--- a/unittests/lift/core/JumpTableEnhancedTests.cpp
+++ b/unittests/lift/core/JumpTableEnhancedTests.cpp
@@ -2533,9 +2533,26 @@ TEST_F(JTE_AArch64, CompactIndexAcceptsExplicitWToXZeroExtension) {
   ASSERT_FALSE(Body.empty()) << R.out;
   EXPECT_TRUE(llvmHasSwitchCase(Body, 0)) << Body;
   EXPECT_TRUE(llvmHasSwitchCase(Body, 1)) << Body;
-  EXPECT_NE(Body.find("i64 2, label"), std::string::npos) << Body;
+  EXPECT_TRUE(llvmHasSwitchCase(Body, 2)) << Body;
   EXPECT_EQ(Body.find("ret i64 399"), std::string::npos) << Body;
   expectSwitchNotOnLoadedEntry(Body, "i8");
+  auto ImageOrErr = neverd::loadBinary(indexIdentityA64Obj());
+  ASSERT_TRUE(static_cast<bool>(ImageOrErr))
+      << llvm::toString(ImageOrErr.takeError());
+  auto Run = runPipelineWithEvidenceBudget(*ImageOrErr,
+                                           neverd::limits::kMaxJumpTableEvidenceWork);
+  ASSERT_TRUE(Run.Result.Success) << Run.Result.Error;
+  const neverd::LowFunc *Function =
+      findLowFunction(Run.Result, "a64_compact_explicit_zext");
+  ASSERT_NE(Function, nullptr);
+  ASSERT_FALSE(Function->JumpTables.empty());
+  ASSERT_FALSE(Function->JumpTables.front().SelectorUseRefs.empty());
+  EXPECT_TRUE(std::all_of(
+      Function->JumpTables.front().SelectorUseRefs.begin(),
+      Function->JumpTables.front().SelectorUseRefs.end(),
+      [](const neverd::JumpTableSelectorUseRef &Ref) {
+        return Ref.ExpectedSize == 4;
+      }));
 }
 
 TEST_F(JTE_AArch64, CompactIndexFollowsExactFrameSpillReload) {
@@ -2543,9 +2560,9 @@ TEST_F(JTE_AArch64, CompactIndexFollowsExactFrameSpillReload) {
   ASSERT_EQ(R.exitCode, 0) << R.err;
   std::string Body = llvmFunctionBody(R.out, "a64_compact_spill_reload");
   ASSERT_FALSE(Body.empty()) << R.out;
-  EXPECT_NE(Body.find("i64 0, label"), std::string::npos) << Body;
-  EXPECT_NE(Body.find("i64 1, label"), std::string::npos) << Body;
-  EXPECT_NE(Body.find("i64 2, label"), std::string::npos) << Body;
+  EXPECT_TRUE(llvmHasSwitchCase(Body, 0)) << Body;
+  EXPECT_TRUE(llvmHasSwitchCase(Body, 1)) << Body;
+  EXPECT_TRUE(llvmHasSwitchCase(Body, 2)) << Body;
   EXPECT_EQ(Body.find("ret i64 499"), std::string::npos) << Body;
   expectSwitchNotOnLoadedEntry(Body, "i8");
 }
@@ -2555,8 +2572,8 @@ TEST_F(JTE_AArch64, CompactIndexRejectsAtomicFrameOverwrite) {
   ASSERT_EQ(R.exitCode, 0) << R.err;
   std::string Body = llvmFunctionBody(R.out, "a64_compact_atomic_overwrite");
   ASSERT_FALSE(Body.empty()) << R.out;
-  EXPECT_NE(Body.find("i64 0, label"), std::string::npos) << Body;
-  EXPECT_NE(Body.find("i64 1, label"), std::string::npos) << Body;
+  EXPECT_TRUE(llvmHasSwitchCase(Body, 0)) << Body;
+  EXPECT_TRUE(llvmHasSwitchCase(Body, 1)) << Body;
   EXPECT_EQ(Body.find("i64 2, label"), std::string::npos) << Body;
   EXPECT_EQ(Body.find("ret i64 1599"), std::string::npos) << Body;
   expectSwitchNotOnLoadedEntry(Body, "i8");

--- a/unittests/lift/core/MedCallingConvTests.cpp
+++ b/unittests/lift/core/MedCallingConvTests.cpp
@@ -104,8 +104,8 @@ MedFunc recoverDirectCallWithArgumentPhis(Arch TheArch, int ArgIdx,
 
   const int Arity = ArgIdx + 1;
   const std::map<va_t, std::string> Names{{Callee, "callee"}};
-  const std::map<va_t, int> RegArity{{Callee, Arity}};
-  const std::map<va_t, int> TotalArity{{Callee, Arity}};
+  std::map<va_t, int> RegArity{{Callee, Arity}};
+  std::map<va_t, int> TotalArity{{Callee, Arity}};
   recoverCallAbi(Func, TheArch, Names, nullptr, &RegArity, &TotalArity);
   return Func;
 }
@@ -360,8 +360,8 @@ TEST(MedABIPass, ForwardedLiveInKeepsParameterProvenance) {
   Func.Blocks[0].Ops.push_back(Return);
 
   const std::map<va_t, std::string> Names{{Callee, "callee"}};
-  const std::map<va_t, int> RegArity{{Callee, 2}};
-  const std::map<va_t, int> TotalArity{{Callee, 2}};
+  std::map<va_t, int> RegArity{{Callee, 2}};
+  std::map<va_t, int> TotalArity{{Callee, 2}};
   recoverCallAbi(Func, TheArch, Names, nullptr, &RegArity, &TotalArity);
 
   ASSERT_EQ(Func.Params.size(), 2u);
@@ -405,8 +405,8 @@ TEST(MedABIPass, PromotedRegisterParamsRebaseMutableStackHomes) {
   Func.Blocks[0].Ops.push_back(Call);
 
   const std::map<va_t, std::string> Names{{Callee, "regparm_callee"}};
-  const std::map<va_t, int> RegArity{{Callee, 2}};
-  const std::map<va_t, int> TotalArity{{Callee, 5}};
+  std::map<va_t, int> RegArity{{Callee, 2}};
+  std::map<va_t, int> TotalArity{{Callee, 5}};
   recoverCallAbi(Func, TheArch, Names, nullptr, &RegArity, &TotalArity);
 
   ASSERT_EQ(Func.Params.size(), 5u);
@@ -491,6 +491,62 @@ TEST(MedABIPass, DirectCallPrefersSeededArgumentPhiOverWiderUndefPhi) {
   ASSERT_EQ(Func.CallInfos[0].Args.size(), 3u);
   EXPECT_EQ(Func.CallInfos[0].Args[2], NarrowPhi);
   EXPECT_EQ(Func.CallInfos[0].Args[2].Size, 4u);
+}
+
+TEST(LowToMedCallReturnFP, DoesNotCrossCallClobber) {
+  constexpr Arch TheArch = Arch::X64;
+  const TargetRegInfo &TRI = getTargetRegInfo(TheArch);
+  LowFunc Low;
+  Low.Entry = 0x1000;
+  Low.Name = "fp_return_call_barrier";
+
+  LowBlock Block;
+  Block.Id = 0;
+  Block.StartAddr = Low.Entry;
+  Block.EndAddr = 0x1018;
+
+  const NdVar WideFP = NdVar::reg(x86reg::XMM0, 16);
+  LowOp Seed;
+  Seed.Opcode = NdOp::COPY;
+  Seed.Addr = 0x1000;
+  Seed.Output = WideFP;
+  Seed.addInput(WideFP);
+  Block.Ops.push_back(Seed);
+
+  auto makeCall = [](va_t Addr, va_t Target) {
+    LowOp Call;
+    Call.Opcode = NdOp::CALL;
+    Call.Addr = Addr;
+    Call.Output = NdVar::reg(x86reg::RAX, 8);
+    Call.addInput(NdVar::cst(Target, 8));
+    return Call;
+  };
+  Block.Ops.push_back(makeCall(0x1004, 0x2000));
+  Block.Ops.push_back(makeCall(0x1008, 0x3000));
+
+  LowOp ReadSecondResult;
+  ReadSecondResult.Opcode = NdOp::COPY;
+  ReadSecondResult.Addr = 0x100c;
+  ReadSecondResult.Output = NdVar::tmp(0x4000, 8);
+  ReadSecondResult.addInput(NdVar::reg(x86reg::XMM0, 8));
+  Block.Ops.push_back(ReadSecondResult);
+
+  LowOp Return;
+  Return.Opcode = NdOp::RETURN;
+  Return.Addr = 0x1010;
+  Return.addInput(ReadSecondResult.Output);
+  Block.Ops.push_back(Return);
+  Low.Blocks.push_back(std::move(Block));
+
+  MedFunc Med = LowToMedConverter().convert(Low, TheArch);
+  ASSERT_EQ(Med.Blocks.size(), 1u);
+  std::vector<const MedOp *> Calls;
+  for (const MedOp &Op : Med.Blocks.front().Ops)
+    if (Op.Opcode == NdOp::CALL)
+      Calls.push_back(&Op);
+  ASSERT_EQ(Calls.size(), 2u);
+  EXPECT_EQ(Calls[0]->Output.RegOff, TRI.IntReturnReg);
+  EXPECT_EQ(Calls[1]->Output.RegOff, TRI.FPReturnReg);
 }
 
 TEST(MedVerifier, AcceptsImplicitCallClobberDefinition) {
@@ -1057,6 +1113,55 @@ llvm::Function *verifiedFunction(llvm::Module &Module, llvm::StringRef Name) {
   llvm::Function *Function = Module.getFunction(Name);
   EXPECT_NE(Function, nullptr);
   return Function;
+}
+
+TEST(MedLLVMReturn, UsesLatestAliasedDefinitionBeforeCoercion) {
+  constexpr Arch TheArch = Arch::X64;
+  const TargetRegInfo &TRI = getTargetRegInfo(TheArch);
+
+  MedFunc Func;
+  Func.Entry = 0x5000;
+  Func.Name = "latest_return_alias";
+  Func.ReturnType = NdType::makeInt(8, false);
+  MedBlock Block;
+  Block.Id = 0;
+  Block.StartAddr = Func.Entry;
+  Block.EndAddr = Func.Entry + 12;
+
+  MedOp Older;
+  Older.Opcode = NdOp::COPY;
+  Older.Output = reg(1, 1, 8, TRI.IntReturnReg, TheArch);
+  Older.addInput(MedVar::makeConst(0x1122334455667788ULL, 8));
+  Block.Ops.push_back(Older);
+
+  MedOp Newer;
+  Newer.Opcode = NdOp::COPY;
+  Newer.Output = reg(2, 1, 4, TRI.IntReturnReg, TheArch);
+  Newer.addInput(MedVar::makeConst(0x55667788, 4));
+  Block.Ops.push_back(Newer);
+
+  MedOp Return;
+  Return.Opcode = NdOp::RETURN;
+  Return.Addr = Func.Entry + 8;
+  Block.Ops.push_back(Return);
+  Func.Blocks.push_back(std::move(Block));
+
+  llvm::LLVMContext Context;
+  auto Module = MedLLVMEmitter().emit({Func}, Context, Func.Name, TheArch);
+  ASSERT_NE(Module, nullptr);
+  llvm::Function *Function = verifiedFunction(*Module, Func.Name);
+  ASSERT_NE(Function, nullptr);
+
+  const llvm::ReturnInst *ReturnInst = nullptr;
+  bool HasZExt = false;
+  for (const llvm::BasicBlock &BB : *Function)
+    for (const llvm::Instruction &Instruction : BB) {
+      if (auto *Candidate = llvm::dyn_cast<llvm::ReturnInst>(&Instruction))
+        ReturnInst = Candidate;
+      HasZExt |= llvm::isa<llvm::ZExtInst>(&Instruction);
+    }
+  ASSERT_NE(ReturnInst, nullptr);
+  EXPECT_TRUE(HasZExt);
 }
 
 TEST(MedLLVMEmitterPredicatedControl,

--- a/unittests/lift/core/MedCallingConvTests.cpp
+++ b/unittests/lift/core/MedCallingConvTests.cpp
@@ -834,69 +834,6 @@ TEST(LowToMedCallReturnFP, CallerSavedPreservingCallKeepsPriorFPResult) {
   EXPECT_TRUE(verifyMedFunc(Med, "test-preserved-fp-result"));
 }
 
-TEST(LowToMedX86CallingConv,
-     StackAddressExtensionDoesNotCreateMutableParameterHome) {
-  constexpr Arch TheArch = Arch::X86;
-  const TargetRegInfo &TRI = getTargetRegInfo(TheArch);
-
-  LowFunc Low;
-  Low.Entry = 0x1000;
-  Low.Name = "extended_stack_parameter_address";
-  Low.Blocks.resize(1);
-  LowBlock &Block = Low.Blocks[0];
-  Block.Id = 0;
-  Block.StartAddr = 0x1000;
-  Block.EndAddr = 0x1004;
-
-  NdVar Address32 = NdVar::tmp(1, TRI.PointerSize);
-  LowOp Add;
-  Add.Opcode = NdOp::INT_ADD;
-  Add.Addr = 0x1000;
-  Add.Output = Address32;
-  Add.addInput(NdVar::reg(TRI.StackPointer, TRI.PointerSize));
-  Add.addInput(NdVar::cst(4, TRI.PointerSize));
-  Block.Ops.push_back(Add);
-
-  NdVar Address64 = NdVar::tmp(2, 8);
-  LowOp Extend;
-  Extend.Opcode = NdOp::INT_ZEXT;
-  Extend.Addr = 0x1001;
-  Extend.Output = Address64;
-  Extend.addInput(Address32);
-  Block.Ops.push_back(Extend);
-
-  NdVar Value = NdVar::tmp(3, 4);
-  LowOp Load;
-  Load.Opcode = NdOp::LOAD;
-  Load.Addr = 0x1002;
-  Load.Output = Value;
-  Load.addInput(Address64);
-  Block.Ops.push_back(Load);
-
-  LowOp Return;
-  Return.Opcode = NdOp::RETURN;
-  Return.Addr = 0x1003;
-  Return.addInput(Value);
-  Block.Ops.push_back(Return);
-
-  MedFunc Med = LowToMedConverter().convert(Low, TheArch);
-  ASSERT_EQ(Med.Params.size(), 1u);
-  EXPECT_EQ(Med.Params[0].Kind, MedVar::Param);
-  EXPECT_EQ(Med.Params[0].Id, 0);
-  EXPECT_EQ(Med.Params[0].RegOff, kNoParamReg);
-  EXPECT_TRUE(Med.MutableStackParamHomes.empty());
-
-  bool SawParameterCopy = false;
-  for (const MedBlock &MedBlock : Med.Blocks)
-    for (const MedOp &Op : MedBlock.Ops) {
-      SawParameterCopy |= Op.Opcode == NdOp::COPY && Op.NumInputs == 1 &&
-                          Op.Inputs[0].Kind == MedVar::Param &&
-                          Op.Inputs[0].Id == 0;
-      EXPECT_NE(Op.Opcode, NdOp::LOAD);
-    }
-  EXPECT_TRUE(SawParameterCopy);
-  EXPECT_TRUE(verifyMedFunc(Med, "test-extended-stack-parameter-address"));
-}
 
 TEST(LowToMedSSA, ModelsItaniumLandingPadRegistersAsExceptionalLiveIns) {
   constexpr Arch TheArch = Arch::AArch64;
@@ -1163,6 +1100,118 @@ TEST(MedLLVMReturn, UsesLatestAliasedDefinitionBeforeCoercion) {
   ASSERT_NE(ReturnInst, nullptr);
   EXPECT_TRUE(HasZExt);
 }
+
+TEST(MedLLVMReturn, UsesLatestFloatDefinitionBeforeWidthPreference) {
+  constexpr Arch TheArch = Arch::X64;
+  const TargetRegInfo &TRI = getTargetRegInfo(TheArch);
+
+  MedFunc Func;
+  Func.Entry = 0x5100;
+  Func.Name = "latest_float_return_alias";
+  Func.ReturnType = NdType::makeFloat(4);
+  MedBlock Block;
+  Block.Id = 0;
+  Block.StartAddr = Func.Entry;
+  Block.EndAddr = Func.Entry + 12;
+
+  MedOp Older;
+  Older.Opcode = NdOp::COPY;
+  Older.Output = reg(1, 1, 16, TRI.fpReturnModelReg(), TheArch);
+  Older.addInput(MedVar::makeConst(0x1122334455667788ULL, 16));
+  Block.Ops.push_back(Older);
+
+  MedOp Newer;
+  Newer.Opcode = NdOp::COPY;
+  Newer.Output = reg(2, 1, 4, TRI.fpReturnModelReg(), TheArch);
+  Newer.addInput(MedVar::makeConst(0x3f800000ULL, 4));
+  Block.Ops.push_back(Newer);
+
+  MedOp Return;
+  Return.Opcode = NdOp::RETURN;
+  Return.Addr = Func.Entry + 8;
+  Block.Ops.push_back(Return);
+  Func.Blocks.push_back(std::move(Block));
+
+  llvm::LLVMContext Context;
+  auto Module = MedLLVMEmitter().emit({Func}, Context, Func.Name, TheArch);
+  ASSERT_NE(Module, nullptr);
+  llvm::Function *Function = verifiedFunction(*Module, Func.Name);
+  ASSERT_NE(Function, nullptr);
+
+  const llvm::ReturnInst *ReturnInst = nullptr;
+  for (const llvm::BasicBlock &BB : *Function)
+    for (const llvm::Instruction &Instruction : BB)
+      if (auto *Candidate = llvm::dyn_cast<llvm::ReturnInst>(&Instruction))
+        ReturnInst = Candidate;
+  ASSERT_NE(ReturnInst, nullptr);
+
+  auto *ReturnBitCast = llvm::dyn_cast<llvm::BitCastInst>(
+      ReturnInst->getReturnValue());
+  ASSERT_NE(ReturnBitCast, nullptr);
+  auto *Widened =
+      llvm::dyn_cast<llvm::ZExtInst>(ReturnBitCast->getOperand(0));
+  ASSERT_NE(Widened, nullptr);
+  EXPECT_EQ(Widened->getSrcTy()->getIntegerBitWidth(), 32u);
+}
+
+TEST(MedLLVMReturn, UsesLatestFloatPredecessorDefinitionBeforeWidthPreference) {
+  constexpr Arch TheArch = Arch::X64;
+  const TargetRegInfo &TRI = getTargetRegInfo(TheArch);
+
+  MedFunc Func;
+  Func.Entry = 0x5200;
+  Func.Name = "latest_float_predecessor_return_alias";
+  Func.ReturnType = NdType::makeFloat(4);
+
+  MedBlock Producer;
+  Producer.Id = 0;
+  Producer.StartAddr = Func.Entry;
+  Producer.EndAddr = Func.Entry + 8;
+  Producer.Succs = {1};
+  MedOp Older;
+  Older.Opcode = NdOp::COPY;
+  Older.Output = reg(1, 1, 16, TRI.fpReturnModelReg(), TheArch);
+  Older.addInput(MedVar::makeConst(0x1122334455667788ULL, 16));
+  Producer.Ops.push_back(Older);
+  MedOp Newer;
+  Newer.Opcode = NdOp::COPY;
+  Newer.Output = reg(2, 1, 4, TRI.fpReturnModelReg(), TheArch);
+  Newer.addInput(MedVar::makeConst(0x3f800000ULL, 4));
+  Producer.Ops.push_back(Newer);
+
+  MedBlock ReturnBlock;
+  ReturnBlock.Id = 1;
+  ReturnBlock.StartAddr = Func.Entry + 8;
+  ReturnBlock.EndAddr = Func.Entry + 12;
+  ReturnBlock.Preds = {0};
+  MedOp Return;
+  Return.Opcode = NdOp::RETURN;
+  Return.Addr = Func.Entry + 8;
+  ReturnBlock.Ops.push_back(Return);
+  Func.Blocks = {std::move(Producer), std::move(ReturnBlock)};
+
+  llvm::LLVMContext Context;
+  auto Module = MedLLVMEmitter().emit({Func}, Context, Func.Name, TheArch);
+  ASSERT_NE(Module, nullptr);
+  llvm::Function *Function = verifiedFunction(*Module, Func.Name);
+  ASSERT_NE(Function, nullptr);
+
+  const llvm::ReturnInst *ReturnInst = nullptr;
+  for (const llvm::BasicBlock &BB : *Function)
+    for (const llvm::Instruction &Instruction : BB)
+      if (auto *Candidate = llvm::dyn_cast<llvm::ReturnInst>(&Instruction))
+        ReturnInst = Candidate;
+  ASSERT_NE(ReturnInst, nullptr);
+
+  auto *ReturnBitCast = llvm::dyn_cast<llvm::BitCastInst>(
+      ReturnInst->getReturnValue());
+  ASSERT_NE(ReturnBitCast, nullptr);
+  auto *Widened =
+      llvm::dyn_cast<llvm::ZExtInst>(ReturnBitCast->getOperand(0));
+  ASSERT_NE(Widened, nullptr);
+  EXPECT_EQ(Widened->getSrcTy()->getIntegerBitWidth(), 32u);
+}
+
 
 TEST(MedLLVMEmitterPredicatedControl,
      DirectAndIndirectCallsExecuteOnlyOnTheFalseGuardEdge) {

--- a/unittests/lift/format/MachOPointerRelocationBoundaryTests.cpp
+++ b/unittests/lift/format/MachOPointerRelocationBoundaryTests.cpp
@@ -301,11 +301,6 @@ public:
     Emitter.CurMedFunc = &Func;
     return Emitter.collectFrameReloadSources(Load, Sources);
   }
-  static std::tuple<uint64_t, uint64_t, uint64_t> frameReloadCounters(
-      const MedLLVMEmitter &Emitter) {
-    return {Emitter.FrameReloadCacheGeneration, Emitter.FrameReloadProofBuilds,
-            Emitter.FrameReloadProofHits};
-  }
 
   static bool recoveredTargetLoadIsFullyConsumed(MedLLVMEmitter &Emitter,
                                                  const MedFunc &Func,
@@ -10333,74 +10328,6 @@ TEST(MachOLLVMDataPointerBoundary,
   const auto Work = MedLLVMProvenanceTestPeer::addressProvenanceWork(Emitter);
   EXPECT_LE(std::get<2>(Work), 2U)
       << "stable-offset cache keys must preserve the optional forbidden value";
-}
-TEST(MachOLLVMDataPointerBoundary, FrameReloadCacheUsesStableOccurrenceIdentity) {
-  MedFunc Func = makeSpilledConstTableLookup(Arch::X64);
-  auto findLoads = [](MedFunc &F) {
-    std::vector<MedOp *> Loads;
-    for (MedBlock &Block : F.Blocks)
-      for (MedOp &Op : Block.Ops)
-        if (Op.Opcode == NdOp::LOAD && Op.NumInputs >= 1)
-          Loads.push_back(&Op);
-    return Loads;
-  };
-
-  auto Loads = findLoads(Func);
-  ASSERT_GE(Loads.size(), 2u);
-  Loads.front()->OriginSeq = 10;
-  MedOp Second = *Loads.front();
-  Second.Output.Id += 100;
-  Second.OriginSeq = 11;
-  Func.Blocks.front().Ops.insert(
-      std::next(Func.Blocks.front().Ops.begin(), 4), std::move(Second));
-  Loads = findLoads(Func);
-  ASSERT_EQ(Loads.size(), 3u);
-  auto FirstIt = std::find_if(Loads.begin(), Loads.end(),
-                              [](const MedOp *Op) { return Op->OriginSeq == 10; });
-  auto SecondIt = std::find_if(Loads.begin(), Loads.end(),
-                               [](const MedOp *Op) { return Op->OriginSeq == 11; });
-  ASSERT_NE(FirstIt, Loads.end());
-  ASSERT_NE(SecondIt, Loads.end());
-
-  MedLLVMEmitter Emitter;
-  std::vector<MedVar> Sources;
-  ASSERT_TRUE(MedLLVMProvenanceTestPeer::collectFrameReloadSources(
-      Emitter, Func, Arch::X64, **FirstIt, Sources));
-  const auto AfterFirst =
-      MedLLVMProvenanceTestPeer::frameReloadCounters(Emitter);
-  EXPECT_EQ(std::get<1>(AfterFirst), 1u);
-  EXPECT_EQ(std::get<2>(AfterFirst), 0u);
-  ASSERT_TRUE(MedLLVMProvenanceTestPeer::collectFrameReloadSources(
-      Emitter, Func, Arch::X64, **FirstIt, Sources));
-  const auto AfterPositiveHit =
-      MedLLVMProvenanceTestPeer::frameReloadCounters(Emitter);
-  EXPECT_EQ(std::get<1>(AfterPositiveHit), 1u);
-  EXPECT_EQ(std::get<2>(AfterPositiveHit), 1u);
-
-  ASSERT_TRUE(MedLLVMProvenanceTestPeer::collectFrameReloadSources(
-      Emitter, Func, Arch::X64, **SecondIt, Sources));
-  const auto AfterDistinctOccurrence =
-      MedLLVMProvenanceTestPeer::frameReloadCounters(Emitter);
-  EXPECT_EQ(std::get<1>(AfterDistinctOccurrence), 2u);
-  EXPECT_EQ(std::get<2>(AfterDistinctOccurrence), 1u);
-
-  MedFunc Other = makeRejectedFrameReloadLookup(
-      Arch::X64, ReachingStoreCase::StoreAfterLoad);
-  auto OtherLoads = findLoads(Other);
-  ASSERT_GE(OtherLoads.size(), 2u);
-  EXPECT_FALSE(MedLLVMProvenanceTestPeer::collectFrameReloadSources(
-      Emitter, Other, Arch::X64, *OtherLoads.front(), Sources));
-  const auto AfterNegativeBuild =
-      MedLLVMProvenanceTestPeer::frameReloadCounters(Emitter);
-  EXPECT_FALSE(MedLLVMProvenanceTestPeer::collectFrameReloadSources(
-      Emitter, Other, Arch::X64, *OtherLoads.front(), Sources));
-  const auto AfterNegativeHit =
-      MedLLVMProvenanceTestPeer::frameReloadCounters(Emitter);
-  EXPECT_EQ(std::get<1>(AfterNegativeHit), std::get<1>(AfterNegativeBuild));
-  EXPECT_EQ(std::get<2>(AfterNegativeHit),
-            std::get<2>(AfterNegativeBuild) + 1);
-  EXPECT_GT(std::get<0>(AfterNegativeHit),
-             std::get<0>(AfterDistinctOccurrence));
 }
 
 TEST(LLVMDataPointerInvariantBoundary,

--- a/unittests/lift/format/MachOPointerRelocationBoundaryTests.cpp
+++ b/unittests/lift/format/MachOPointerRelocationBoundaryTests.cpp
@@ -214,6 +214,8 @@ public:
       Emitter.FrameDerivedCache[{1, 1}] = true;
       Emitter.FrameAddressCacheFor = Emitter.CurMedFunc;
       Emitter.FrameAddressCache[{2, 2}] = true;
+      Emitter.FrameReloadCacheFor = Emitter.CurMedFunc;
+      Emitter.FrameReloadCache[MedLLVMEmitter::FrameReloadCacheKey{}] = {};
 
       const auto Result = Emitter.classifyPhiIncomingEdge(Phi, PredId);
       ObservedProvisionalQuery =
@@ -242,7 +244,9 @@ public:
            Emitter.FrameDerivedCacheFor == nullptr &&
            Emitter.FrameDerivedCache.empty() &&
            Emitter.FrameAddressCacheFor == nullptr &&
-           Emitter.FrameAddressCache.empty();
+           Emitter.FrameAddressCache.empty() &&
+           Emitter.FrameReloadCacheFor == nullptr &&
+           Emitter.FrameReloadCache.empty();
   }
 
   static bool stableOffset(MedLLVMEmitter &Emitter, const MedVar &Value,
@@ -296,6 +300,11 @@ public:
     Emitter.TargetArch = TargetArch;
     Emitter.CurMedFunc = &Func;
     return Emitter.collectFrameReloadSources(Load, Sources);
+  }
+  static std::tuple<uint64_t, uint64_t, uint64_t> frameReloadCounters(
+      const MedLLVMEmitter &Emitter) {
+    return {Emitter.FrameReloadCacheGeneration, Emitter.FrameReloadProofBuilds,
+            Emitter.FrameReloadProofHits};
   }
 
   static bool recoveredTargetLoadIsFullyConsumed(MedLLVMEmitter &Emitter,
@@ -10324,6 +10333,74 @@ TEST(MachOLLVMDataPointerBoundary,
   const auto Work = MedLLVMProvenanceTestPeer::addressProvenanceWork(Emitter);
   EXPECT_LE(std::get<2>(Work), 2U)
       << "stable-offset cache keys must preserve the optional forbidden value";
+}
+TEST(MachOLLVMDataPointerBoundary, FrameReloadCacheUsesStableOccurrenceIdentity) {
+  MedFunc Func = makeSpilledConstTableLookup(Arch::X64);
+  auto findLoads = [](MedFunc &F) {
+    std::vector<MedOp *> Loads;
+    for (MedBlock &Block : F.Blocks)
+      for (MedOp &Op : Block.Ops)
+        if (Op.Opcode == NdOp::LOAD && Op.NumInputs >= 1)
+          Loads.push_back(&Op);
+    return Loads;
+  };
+
+  auto Loads = findLoads(Func);
+  ASSERT_GE(Loads.size(), 2u);
+  Loads.front()->OriginSeq = 10;
+  MedOp Second = *Loads.front();
+  Second.Output.Id += 100;
+  Second.OriginSeq = 11;
+  Func.Blocks.front().Ops.insert(
+      std::next(Func.Blocks.front().Ops.begin(), 4), std::move(Second));
+  Loads = findLoads(Func);
+  ASSERT_EQ(Loads.size(), 3u);
+  auto FirstIt = std::find_if(Loads.begin(), Loads.end(),
+                              [](const MedOp *Op) { return Op->OriginSeq == 10; });
+  auto SecondIt = std::find_if(Loads.begin(), Loads.end(),
+                               [](const MedOp *Op) { return Op->OriginSeq == 11; });
+  ASSERT_NE(FirstIt, Loads.end());
+  ASSERT_NE(SecondIt, Loads.end());
+
+  MedLLVMEmitter Emitter;
+  std::vector<MedVar> Sources;
+  ASSERT_TRUE(MedLLVMProvenanceTestPeer::collectFrameReloadSources(
+      Emitter, Func, Arch::X64, **FirstIt, Sources));
+  const auto AfterFirst =
+      MedLLVMProvenanceTestPeer::frameReloadCounters(Emitter);
+  EXPECT_EQ(std::get<1>(AfterFirst), 1u);
+  EXPECT_EQ(std::get<2>(AfterFirst), 0u);
+  ASSERT_TRUE(MedLLVMProvenanceTestPeer::collectFrameReloadSources(
+      Emitter, Func, Arch::X64, **FirstIt, Sources));
+  const auto AfterPositiveHit =
+      MedLLVMProvenanceTestPeer::frameReloadCounters(Emitter);
+  EXPECT_EQ(std::get<1>(AfterPositiveHit), 1u);
+  EXPECT_EQ(std::get<2>(AfterPositiveHit), 1u);
+
+  ASSERT_TRUE(MedLLVMProvenanceTestPeer::collectFrameReloadSources(
+      Emitter, Func, Arch::X64, **SecondIt, Sources));
+  const auto AfterDistinctOccurrence =
+      MedLLVMProvenanceTestPeer::frameReloadCounters(Emitter);
+  EXPECT_EQ(std::get<1>(AfterDistinctOccurrence), 2u);
+  EXPECT_EQ(std::get<2>(AfterDistinctOccurrence), 1u);
+
+  MedFunc Other = makeRejectedFrameReloadLookup(
+      Arch::X64, ReachingStoreCase::StoreAfterLoad);
+  auto OtherLoads = findLoads(Other);
+  ASSERT_GE(OtherLoads.size(), 2u);
+  EXPECT_FALSE(MedLLVMProvenanceTestPeer::collectFrameReloadSources(
+      Emitter, Other, Arch::X64, *OtherLoads.front(), Sources));
+  const auto AfterNegativeBuild =
+      MedLLVMProvenanceTestPeer::frameReloadCounters(Emitter);
+  EXPECT_FALSE(MedLLVMProvenanceTestPeer::collectFrameReloadSources(
+      Emitter, Other, Arch::X64, *OtherLoads.front(), Sources));
+  const auto AfterNegativeHit =
+      MedLLVMProvenanceTestPeer::frameReloadCounters(Emitter);
+  EXPECT_EQ(std::get<1>(AfterNegativeHit), std::get<1>(AfterNegativeBuild));
+  EXPECT_EQ(std::get<2>(AfterNegativeHit),
+            std::get<2>(AfterNegativeBuild) + 1);
+  EXPECT_GT(std::get<0>(AfterNegativeHit),
+             std::get<0>(AfterDistinctOccurrence));
 }
 
 TEST(LLVMDataPointerInvariantBoundary,


### PR DESCRIPTION
## Summary

This PR supersedes the closed #92 and consolidates its ABI/provenance correctness fixes with the frame-reload proof-cache optimization.

The branch is based on the current `dev` line and no longer carries the old stacked history from `58eb1cc`/`e2be1dd`.

## Correctness fixes

- Harden variadic detection with exact va-list consumer identity, call-site SSA binding, entry-SP provenance, and fail-closed ambiguity handling.
- Preserve fixed register prefixes for Darwin AArch64 variadic wrappers.
- Recover ARM32/AArch64 and 32-bit register-pair return values without dropping authoritative width information.
- Select the newest authoritative return-register write; an older wider XMM/vector write cannot override a newer narrow write.
- Keep jump-table evidence through ownership resolution and authenticate selector domains from exact occurrences and reachable guard evidence.
- Separate physical storage ownership from callable/data role ownership.
- Reject stale absolute-address fallbacks when relocation or provenance ownership is incomplete.
- Preserve frame headroom for variadic overflow arguments and mutable incoming stack-parameter homes.

## Frame-reload proof cache

`collectFrameReloadSources()` uses two layers:

1. A stable occurrence index and a per-function immutable MedIR snapshot containing copied block successors, structural predecessors, memory writes, and load sites.
2. A completed-proof cache keyed by stable occurrence identity:

   `(Addr, OriginSeq, Width, Address SSA identity, Output SSA identity)`

The cache:

- Stores only MedIR values and completed proof results.
- Caches both positive and fail-closed negative results.
- Does not publish results while feasible-edge construction is `Building`.
- Clears its snapshot and results at module reuse boundaries and feasible-edge invalidation boundaries.
- Does not use `const MedOp*` or `const MedFunc*` as proof identity.

## Validation

- `NeverDLiftTests`: `2341 passed`, `2 skipped`, `0 failed`.
- `NeverDLibCTests`: `34/34 passed`.
- `/usr/bin/file` lifted with `--no-opt` successfully.
- Lifted IR compiled and linked with project clang-23 and the macOS 15.4 SDK.
- The linked lifted executable correctly identified `/usr/bin/file` as a Mach-O universal binary and identified a C source file.
- `git diff --check` passed.

The two skipped lift tests are optional real-binary parity tests. Full CTest remains subject to the existing vendored Unicorn `__int128_t` typedef conflict.

## Relationship to #92

PR #92 has been closed. This PR is its replacement and includes the ABI, provenance, jump-table, fail-closed, return-width, frame-allocation, and frame-reload-cache changes in one current-dev-based branch.
